### PR TITLE
Rename model to estimator

### DIFF
--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -59,7 +59,7 @@ class ChemPropSingleTaskRegressorModel(PickleableModelBase):
                 self.batch_norm,
                 metric_list,
             )
-            self._model = mpnn
+            self.estimator = mpnn
 
         else:
             logger.warning("Model already exists, skipping build")
@@ -68,13 +68,13 @@ class ChemPropSingleTaskRegressorModel(PickleableModelBase):
         """
         Predict using the model
         """
-        if not self.model:
+        if not self.estimator:
             raise AttributeError("Model not trained")
 
         with torch.inference_mode():
             trainer = pl.Trainer(
                 logger=None, enable_progress_bar=False, accelerator="auto", devices=1
             )
-            preds = trainer.predict(self.model, X)
+            preds = trainer.predict(self.estimator, X)
         # concatenate the predictions which are in a list of tensors
         return torch.cat(preds).numpy().ravel()

--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -45,7 +45,7 @@ class ChemPropSingleTaskRegressorModel(PickleableModelBase):
         """
         Prepare the model
         """
-        if not self.model:
+        if not self.estimator:
             if scaler is not None:
                 output_transform = nn.UnscaleTransform.from_standard_scaler(scaler)
             else:

--- a/openadmet/models/architecture/lgbm.py
+++ b/openadmet/models/architecture/lgbm.py
@@ -31,7 +31,7 @@ class LGBMRegressorModel(PickleableModelBase):
         Train the model
         """
         self.build()
-        self.model = self.model.fit(X, y)
+        self.estimator = self.estimator.fit(X, y)
 
     def build(self):
         """

--- a/openadmet/models/architecture/lgbm.py
+++ b/openadmet/models/architecture/lgbm.py
@@ -37,8 +37,8 @@ class LGBMRegressorModel(PickleableModelBase):
         """
         Prepare the model
         """
-        if not self.model:
-            self.model = lgb.LGBMRegressor(**self.model_params)
+        if not self.estimator:
+            self.estimator = lgb.LGBMRegressor(**self.model_params)
         else:
             logger.warning("Model already exists, skipping build")
 
@@ -46,6 +46,6 @@ class LGBMRegressorModel(PickleableModelBase):
         """
         Predict using the model
         """
-        if not self.model:
+        if not self.estimator:
             raise ValueError("Model not trained")
-        return self.model.predict(X)
+        return self.estimator.predict(X)

--- a/openadmet/models/architecture/model_base.py
+++ b/openadmet/models/architecture/model_base.py
@@ -28,7 +28,7 @@ class ModelBase(BaseModel, ABC):
         return self._model
 
     @model.setter
-    def model(self, value):
+    def estimator(self, value):
         self._model = value
 
     @abstractmethod

--- a/openadmet/models/architecture/model_base.py
+++ b/openadmet/models/architecture/model_base.py
@@ -29,7 +29,7 @@ class ModelBase(BaseModel, ABC):
 
     @model.setter
     def estimator(self, value):
-        self._model = value
+        self._estimator = value
 
     @abstractmethod
     def from_params(cls, class_params: dict, model_params: dict):

--- a/openadmet/models/architecture/model_base.py
+++ b/openadmet/models/architecture/model_base.py
@@ -21,13 +21,13 @@ def get_model_class(model_type):
 
 
 class ModelBase(BaseModel, ABC):
-    _model: Any = None
+    _estimator: Any = None
 
     @property
-    def model(self):
-        return self._model
+    def estimator(self):
+        return self._estimator
 
-    @model.setter
+    @estimator.setter
     def estimator(self, value):
         self._estimator = value
 
@@ -101,16 +101,16 @@ class PickleableModelBase(ModelBase):
 
     def save(self, path: PathLike):
 
-        if self.model is None:
+        if self.estimator is None:
             raise ValueError("Model is not built, cannot save")
 
         with open(path, "wb") as f:
-            joblib.dump(self.model, f)
+            joblib.dump(self.estimator, f)
 
     def load(self, path: PathLike):
 
         with open(path, "rb") as f:
-            self._model = joblib.load(f)
+            self._estimator = joblib.load(f)
 
     @classmethod
     def deserialize(
@@ -138,10 +138,10 @@ class PickleableModelBase(ModelBase):
 
 class TorchModelBase(ModelBase):
     def save(self, path: PathLike):
-        torch.save(self.model.state_dict(), path)
+        torch.save(self.estimator.state_dict(), path)
 
     def load(self, path: PathLike):
-        self.model.load_state_dict(torch.load(path))
+        self.estimator.load_state_dict(torch.load(path))
 
     def serialize(
         self, param_path: PathLike = "model.json", serial_path: PathLike = "model.pth"

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -93,7 +93,7 @@ class SKLearnRepeatedKFoldCrossValidation(EvalBase):
             random_state=self.random_state,
         )
 
-        estimator = model.model
+        estimator = model.estimator
         # evaluate the model, storing the results
         # we do one job here to avoid issues with double parallelization
         # we prefer to parallelize model training over cross-validation

--- a/openadmet/models/tests/models/test_lgbm.py
+++ b/openadmet/models/tests/models/test_lgbm.py
@@ -22,8 +22,8 @@ def test_lgbm_from_params():
         class_params={}, model_params={"n_estimators": 100, "boosting_type": "rf"}
     )
     assert lgbm_model.type == "LGBMRegressorModel"
-    assert lgbm_model.model.get_params()["n_estimators"] == 100
-    assert lgbm_model.model.get_params()["boosting_type"] == "rf"
+    assert lgbm_model.estimator.get_params()["n_estimators"] == 100
+    assert lgbm_model.estimator.get_params()["boosting_type"] == "rf"
 
 
 def test_lgbm_train_predict(X_y):

--- a/openadmet/models/tests/test_data/basic_anvil.yaml
+++ b/openadmet/models/tests/test_data/basic_anvil.yaml
@@ -45,8 +45,7 @@ procedure:
         learning_rate: 0.1
 
   train:
-    type: SKLearnGridSearchTrainer
-    #type: SKLearnBasicTrainer
+    type: SKLearnBasicTrainer
 
 
 report:

--- a/openadmet/models/tests/test_data/basic_anvil.yaml
+++ b/openadmet/models/tests/test_data/basic_anvil.yaml
@@ -45,7 +45,8 @@ procedure:
         learning_rate: 0.1
 
   train:
-    type: SKLearnBasicTrainer
+    type: SKLearnGridSearchTrainer
+    #type: SKLearnBasicTrainer
 
 
 report:

--- a/openadmet/models/trainer/lightning.py
+++ b/openadmet/models/trainer/lightning.py
@@ -60,6 +60,6 @@ class LightningTrainer(TrainerBase):
         """
         Train the model
         """
-        logger.info(f"Training model {self.model._model}")
-        self._trainer.fit(self.model._model, train_dataloader)
+        logger.info(f"Training model {self.model._estimator}")
+        self._trainer.fit(self.model._estimator, train_dataloader)
         return self.model

--- a/openadmet/models/trainer/sklearn.py
+++ b/openadmet/models/trainer/sklearn.py
@@ -13,9 +13,9 @@ class SKlearnBasicTrainer(TrainerBase):
     """
 
     def train(self, X: Any, y: Any):
-        sklearn_model = self.model.model
+        sklearn_model = self.model.estimator
         sklearn_model.fit(X, y)
-        self.model.model = sklearn_model
+        self.model.estimator = sklearn_model
         return self.model
 
 
@@ -47,11 +47,11 @@ class SKLearnGridSearchTrainer(SKLearnSearchTrainer):
         """
         Train the model
         """
-        sklearn_model = self.model.model
+        sklearn_model = self.model.estimator
         self.search = GridSearchCV(sklearn_model, param_grid=self.param_grid)
         self.search.fit(X, y)
         # set the params and model to the best found
-        self.model.model = self.search.best_estimator_
-        self.model.model_params = self.model.model.get_params()
+        self.model.estimator = self.search.best_estimator_
+        self.model.model_params = self.model.estimator.get_params()
         logger.info(f"Best params: {self.model.model_params}")
         return self.model


### PR DESCRIPTION
Created to satisfy Issue #44 

I simply changed 

```python
class ModelBase(BaseModel, ABC):
    _model: Any = None

    @property
    def model(self):
        return self._model

    @model.setter
    def model(self, value):
        self._model = value
```

to 

```python
class ModelBase(BaseModel, ABC):
    _model: Any = None

    @property
    def model(self):
        return self._model

    @model.setter
    def estimator(self, value):
        self._model = value
``` 

Let me know if this does not completely satisfy the issue. 

I explored the repo and tried to find at any point where this functionality was called, and could not find any location. Also, the test code continued to run well. Let me know if I have missed anything. 
