### PR TITLE
Setup for Flexible device selection (gpu vs cpu)

### DIFF
--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -436,9 +436,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         logger.info("Model saved")
 
         logger.info("Predicting")
-        accelerator = getattr(self.trainer, "accelerator", "gpu")
-        devices = getattr(self.trainer, "devices", 1)
-        y_pred = self.model.predict(test_dataloader, accelerator=accelerator, devices=devices)
+        y_pred = self.model.predict(test_dataloader, accelerator=self.trainer.accelerator, devices=self.trainer.devices)
         logger.info("Predictions made")
 
         logger.info("Evaluating")

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -436,7 +436,9 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
         logger.info("Model saved")
 
         logger.info("Predicting")
-        y_pred = self.model.predict(test_dataloader)
+        accelerator = getattr(self.trainer, "accelerator", "gpu")
+        devices = getattr(self.trainer, "devices", 1)
+        y_pred = self.model.predict(test_dataloader, accelerator=accelerator, devices=devices)
         logger.info("Predictions made")
 
         logger.info("Evaluating")

--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -102,7 +102,7 @@ class ChemPropSingleTaskRegressorModel(PickleableModelBase):
         else:
             logger.warning("Model already exists, skipping build")
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    def predict(self, X: np.ndarray, accelerator="gpu", devices=1) -> np.ndarray:
         """
         Predict using the model
         """
@@ -111,7 +111,7 @@ class ChemPropSingleTaskRegressorModel(PickleableModelBase):
 
         with torch.inference_mode():
             trainer = pl.Trainer(
-                logger=None, enable_progress_bar=False, accelerator="auto", devices=1
+                logger=None, enable_progress_bar=False, accelerator=accelerator, devices=devices
             )
             preds = trainer.predict(self.estimator, X)
         # concatenate the predictions which are in a list of tensors

--- a/openadmet/models/architecture/mtenn.py
+++ b/openadmet/models/architecture/mtenn.py
@@ -76,7 +76,7 @@ class MTENNSchNetModel(TorchModelBase):
            "Training not implemented in model class, use a trainer."
         )
 
-    def predict(self, dataloader) -> torch.Tensor:
+    def predict(self, dataloader, accelerator="gpu", devices=1) -> torch.Tensor:
         """
         Use model for prediction
         """
@@ -84,9 +84,7 @@ class MTENNSchNetModel(TorchModelBase):
             raise AttributeError("Model not built or trained.")
 
         with torch.inference_mode():
-            acc = "cpu"
-            #acc = "gpu"	#uncomment line and comment above for gpu usage; if auto doesnt work change string to gpu
             trainer = pl.Trainer(
-                logger=None, enable_progress_bar=False, accelerator=acc, devices=1)
+                logger=None, enable_progress_bar=False, accelerator=accelerator, devices=devices)
             preds = trainer.predict(self.estimator, dataloader)
         return torch.cat(preds).numpy().ravel()


### PR DESCRIPTION
Satisfies Issue #106 
Making changes to workflow so that user can select gpu or cpu for deep learning pytorch workflows. GPU is set to default, but simply adding cpu to training params in yaml file will allow for cpu usage rather than gpu. 

Done:
- Add accelerator and devices to predict workflow in AnvilDeeplearningWorkflow class. This specifies that we will use the same accelerator and device as we used for the training step. 
- Update MTENNSchNetModel predict function to take accelerator and devices as input variables. 

ToDo:
- Update/check chemprop predict function to align with new workflow capabilities
- Add basic test yaml file for cpu usage
