### PR TITLE
Fix/218/improve eval fig

### DIFF
--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -21,6 +21,8 @@ from openadmet.models.eval.regression import (
     nan_omit_spearmanr,
 )
 from openadmet.models.trainer.lightning import LightningTrainer
+from openadmet.models.eval.utils import _make_stat_caption, _make_stat_dict
+
 
 
 def wrap_ktau(y_true, y_pred):
@@ -173,13 +175,13 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
         self.plot_data = {}
 
         # stat_caption = self.make_stat_caption(t_label)
-        stat_dict = self.make_stat_dict(t_label)
+        stat_dict = self.get_stat_dict(t_label=t_label)
 
         # create the plots
         for plot_tag, plot in self.plots.items():
             if "ciplot" in plot_tag:
                 self.plot_data[plot_tag] = plot(stat_dict=stat_dict)
-            else:
+            elif "regplot" in plot_tag:
                 self.plot_data[plot_tag] = plot(
                     y_true,
                     y_pred,
@@ -194,55 +196,23 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
                 )
 
         return self.data
-
-    def make_stat_caption(self, task_name):
-        """
-        Make a caption for the statistics
-        """
-        print("Making stat caption")
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-        stat_caption = ""
-
-        stat_caption += f"## {task_name} ##\n"
-        for metric in self.metric_names:
-            value = self.data[task_name][metric]["mean"]
-            lower_ci = self.data[task_name][metric]["lower_ci"]
-            upper_ci = self.data[task_name][metric]["upper_ci"]
-            confidence_level = self.data[task_name][metric]["confidence_level"]
-            stat_caption += f"{self._metrics[metric][2]}: {value:.2f}$_{{{lower_ci:.2f}}}^{{{upper_ci:.2f}}}$\n"
-            stat_caption += "\n"
-        stat_caption += f"Confidence level: {confidence_level} \n"
-        return stat_caption
-
-    def make_stat_dict(self, task_name):
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-
-        stat_dict = {
-            "metrics": [],
-            "means": [],
-            "lower_ci": [],
-            "upper_ci": [],
-            "conf_level": None,
-            "task_name" : None
-        }
-
-        stat_dict["task_name"] = task_name
-
-        for metric in self.metric_names:
-            value = self.data[task_name][metric]["mean"]
-            lower_ci = self.data[task_name][metric]["lower_ci"]
-            upper_ci = self.data[task_name][metric]["upper_ci"]
-            confidence_level = self.data[task_name][metric]["confidence_level"]
-
-            # Save in dict
-            stat_dict["metrics"].append(self._metrics[metric][2])
-            stat_dict["means"].append(float(value))
-            stat_dict["lower_ci"].append(float(lower_ci))
-            stat_dict["upper_ci"].append(float(upper_ci))
-            stat_dict["conf_level"] = confidence_level
-        return stat_dict
+    def get_stat_caption(self, t_label):
+        return _make_stat_caption(data=self.data,
+                                  task_name=t_label,
+                                  metric_names=self.metric_names,
+                                  metrics=self._metrics,
+                                  bootstrap_confidence_level=self.confidence_level,
+                                  evaluated=self._evaluated,
+                                  cv=True)
+    
+    def get_stat_dict(self, t_label):
+        return _make_stat_dict(data=self.data,
+                               task_name=t_label,
+                               metric_names=self.metric_names,
+                               metrics=self._metrics,
+                               bootstrap_confidence_level=self.confidence_level,
+                               evaluated=self._evaluated,
+                               cv=True)
 
     def report(self, write=False, output_dir=None):
         """
@@ -477,14 +447,14 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             t_label = target_labels[task_id]
 
             # stat_caption = self.make_stat_caption(t_label)
-            stat_dict = self.make_stat_dict(t_label)
+            stat_dict = self.get_stat_dict(t_label=t_label)
 
             # create the plots
             for plot_tag, plot in self.plots.items():
                 plot_tag_task = f"{plot_tag}_{t_label}"
                 if "ciplot" in plot_tag_task:
                     self.plot_data[plot_tag_task] = plot(stat_dict=stat_dict)
-                else:
+                elif "regplot" in plot_tag_task:
                     self.plot_data[plot_tag_task] = plot(
                         t_true,
                         t_pred,
@@ -529,51 +499,20 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
         for plot_tag, plot in self.plot_data.items():
             plot.savefig(output_dir / f"{plot_tag}.png", bbox_inches="tight", dpi=900)
 
-    def make_stat_caption(self, task_name):
-        """
-        Make a caption for the statistics
-        """
-        print("Making stat caption")
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-        stat_caption = ""
-
-        stat_caption += f"## {task_name} ##\n"
-        for metric in self.metric_names:
-            value = self.data[task_name][metric]["mean"]
-            lower_ci = self.data[task_name][metric]["lower_ci"]
-            upper_ci = self.data[task_name][metric]["upper_ci"]
-            confidence_level = self.data[task_name][metric]["confidence_level"]
-            stat_caption += f"{self._metrics[metric][2]}: {value:.2f}$_{{{lower_ci:.2f}}}^{{{upper_ci:.2f}}}$\n"
-            stat_caption += "\n"
-        stat_caption += f"Confidence level: {confidence_level} \n"
-        return stat_caption
-
-    def make_stat_dict(self, task_name):
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-
-        stat_dict = {
-            "metrics": [],
-            "means": [],
-            "lower_ci": [],
-            "upper_ci": [],
-            "conf_level": None,
-            "task_name" : None
-        }
-
-        stat_dict["task_name"] = task_name
-
-        for metric in self.metric_names:
-            value = self.data[task_name][metric]["mean"]
-            lower_ci = self.data[task_name][metric]["lower_ci"]
-            upper_ci = self.data[task_name][metric]["upper_ci"]
-            confidence_level = self.data[task_name][metric]["confidence_level"]
-
-            # Save in dict
-            stat_dict["metrics"].append(self._metrics[metric][2])
-            stat_dict["means"].append(value)
-            stat_dict["lower_ci"].append(lower_ci)
-            stat_dict["upper_ci"].append(upper_ci)
-            stat_dict["conf_level"] = confidence_level
-        return stat_dict
+    def get_stat_caption(self, t_label):
+        return _make_stat_caption(data=self.data,
+                                  task_name=t_label,
+                                  metric_names=self.metric_names,
+                                  metrics=self._metrics,
+                                  bootstrap_confidence_level=self.confidence_level,
+                                  evaluated=self._evaluated,
+                                  cv=True)
+    
+    def get_stat_dict(self, t_label):
+        return _make_stat_dict(data=self.data,
+                               task_name=t_label,
+                               metric_names=self.metric_names,
+                               metrics=self._metrics,
+                               bootstrap_confidence_level=self.confidence_level,
+                               evaluated=self._evaluated,
+                               cv=True)

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -167,27 +167,31 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
 
         self.plots = {
             "cross_validation_regplot": RegressionPlots.regplot,
+            "cross_validation_ciplot": RegressionPlots.ciplot
         }
 
         self.plot_data = {}
 
-        stat_caption = self.make_stat_caption(t_label)
+        # stat_caption = self.make_stat_caption(t_label)
         stat_dict = self.make_stat_dict(t_label)
 
         # create the plots
         for plot_tag, plot in self.plots.items():
-            self.plot_data[plot_tag] = plot(
-                y_true,
-                y_pred,
-                xlabel=self.axes_labels[0],
-                ylabel=self.axes_labels[1],
-                title=f"{self.title}\nTask: {t_label}",
-                stat_caption=stat_caption,
-                stat_dict=stat_dict,
-                pXC50=self.pXC50,
-                min_val=self.min_val,
-                max_val=self.max_val,
-            )
+            if "ciplot" in plot_tag:
+                self.plot_data[plot_tag] = plot(stat_dict=stat_dict)
+            else:
+                self.plot_data[plot_tag] = plot(
+                    y_true,
+                    y_pred,
+                    xlabel=self.axes_labels[0],
+                    ylabel=self.axes_labels[1],
+                    title=f"{self.title}\nTask: {t_label}",
+                    # stat_caption=stat_caption,
+                    stat_dict=stat_dict,
+                    pXC50=self.pXC50,
+                    min_val=self.min_val,
+                    max_val=self.max_val,
+                )
 
         return self.data
 
@@ -215,9 +219,17 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
         if not self._evaluated:
             raise ValueError("Must evaluate before making a caption")
         
-        stat_dict = {}
-
+        stat_dict = {
+            "metrics": [],
+            "means": [],
+            "lower_ci": [],
+            "upper_ci": [],
+            "conf_level": None,
+            "task_name" : None
+        }
+        
         stat_dict["task_name"] = task_name
+
         for metric in self.metric_names:
             value = self.data[task_name][metric]["mean"]
             lower_ci = self.data[task_name][metric]["lower_ci"]
@@ -225,8 +237,11 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             confidence_level = self.data[task_name][metric]["confidence_level"]
 
             # Save in dict
-            stat_dict[self._metrics[metric][2]] = f"{value:.2f} [{lower_ci:.2f}, {upper_ci:.2f}]"
-        stat_dict["conf_level"] = confidence_level
+            stat_dict["metrics"].append(self._metrics[metric][2])
+            stat_dict["means"].append(float(value))
+            stat_dict["lower_ci"].append(float(lower_ci))
+            stat_dict["upper_ci"].append(float(upper_ci))
+            stat_dict["conf_level"] = confidence_level
         return stat_dict
 
     def report(self, write=False, output_dir=None):
@@ -247,7 +262,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
 
         # write each plot to a file
         for plot_tag, plot in self.plot_data.items():
-            plot.savefig(output_dir / f"{plot_tag}.png", dpi=900)
+            plot.savefig(output_dir / f"{plot_tag}.png", bbox_inches="tight", dpi=900)
 
 
 @evaluators.register("PytorchLightningRepeatedKFoldCrossValidation")
@@ -448,6 +463,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
 
         self.plots = {
             "cross_validation_regplot": RegressionPlots.regplot,
+            "cross_validation_ciplot": RegressionPlots.ciplot
         }
 
         self.plot_data = {}
@@ -460,22 +476,27 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             t_true, t_pred = mask_nans(t_true, t_pred)
             t_label = target_labels[task_id]
 
-            stat_caption = self.make_stat_caption(t_label)
+            # stat_caption = self.make_stat_caption(t_label)
+            stat_dict = self.make_stat_dict(t_label)
 
             # create the plots
             for plot_tag, plot in self.plots.items():
                 plot_tag_task = f"{plot_tag}_{t_label}"
-                self.plot_data[plot_tag_task] = plot(
-                    t_true,
-                    t_pred,
-                    xlabel=self.axes_labels[0],
-                    ylabel=self.axes_labels[1],
-                    title=f"{self.title}\nTask: {t_label}",
-                    stat_caption=stat_caption,
-                    pXC50=self.pXC50,
-                    min_val=self.min_val,
-                    max_val=self.max_val,
-                )
+                if "ciplot" in plot_tag_task:
+                    self.plot_data[plot_tag_task] = plot(stat_dict=stat_dict)
+                else:
+                    self.plot_data[plot_tag_task] = plot(
+                        t_true,
+                        t_pred,
+                        xlabel=self.axes_labels[0],
+                        ylabel=self.axes_labels[1],
+                        title=f"{self.title}\nTask: {t_label}",
+                        # stat_caption=stat_caption,
+                        stat_dict=stat_dict,
+                        pXC50=self.pXC50,
+                        min_val=self.min_val,
+                        max_val=self.max_val,
+                    )
 
         return self.data
 
@@ -506,7 +527,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
 
         # write each plot to a file
         for plot_tag, plot in self.plot_data.items():
-            plot.savefig(output_dir / f"{plot_tag}.png", dpi=900)
+            plot.savefig(output_dir / f"{plot_tag}.png", bbox_inches="tight", dpi=900)
 
     def make_stat_caption(self, task_name):
         """
@@ -527,3 +548,32 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
+    
+    def make_stat_dict(self, task_name):
+        if not self._evaluated:
+            raise ValueError("Must evaluate before making a caption")
+        
+        stat_dict = {
+            "metrics": [],
+            "means": [],
+            "lower_ci": [],
+            "upper_ci": [],
+            "conf_level": None,
+            "task_name" : None
+        }
+
+        stat_dict["task_name"] = task_name
+
+        for metric in self.metric_names:
+            value = self.data[task_name][metric]["mean"]
+            lower_ci = self.data[task_name][metric]["lower_ci"]
+            upper_ci = self.data[task_name][metric]["upper_ci"]
+            confidence_level = self.data[task_name][metric]["confidence_level"]
+
+            # Save in dict
+            stat_dict["metrics"].append(self._metrics[metric][2])
+            stat_dict["means"].append(value)
+            stat_dict["lower_ci"].append(lower_ci)
+            stat_dict["upper_ci"].append(upper_ci)
+            stat_dict["conf_level"] = confidence_level
+        return stat_dict

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -174,7 +174,6 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
 
         self.plot_data = {}
 
-        # stat_caption = self.make_stat_caption(t_label)
         stat_dict = self.get_stat_dict(t_label=t_label)
 
         # create the plots
@@ -188,7 +187,6 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
                     xlabel=self.axes_labels[0],
                     ylabel=self.axes_labels[1],
                     title=f"{self.title}\nTask: {t_label}",
-                    # stat_caption=stat_caption,
                     stat_dict=stat_dict,
                     pXC50=self.pXC50,
                     min_val=self.min_val,
@@ -197,21 +195,23 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
 
         return self.data
     def get_stat_caption(self, t_label):
+        if not self._evaluated:
+            raise ValueError(":( You must evaluate the model before the statistics caption can be made.")
         return _make_stat_caption(data=self.data,
                                   task_name=t_label,
                                   metric_names=self.metric_names,
                                   metrics=self._metrics,
-                                  bootstrap_confidence_level=self.confidence_level,
-                                  evaluated=self._evaluated,
+                                  confidence_level=self.confidence_level,
                                   cv=True)
 
     def get_stat_dict(self, t_label):
+        if not self._evaluated:
+            raise ValueError("R'uh-r'oh! You must evaluate the model before the statistics dict can be made.")
         return _make_stat_dict(data=self.data,
                                task_name=t_label,
                                metric_names=self.metric_names,
                                metrics=self._metrics,
-                               bootstrap_confidence_level=self.confidence_level,
-                               evaluated=self._evaluated,
+                               confidence_level=self.confidence_level,
                                cv=True)
 
     def report(self, write=False, output_dir=None):
@@ -446,7 +446,6 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             t_true, t_pred = mask_nans(t_true, t_pred)
             t_label = target_labels[task_id]
 
-            # stat_caption = self.make_stat_caption(t_label)
             stat_dict = self.get_stat_dict(t_label=t_label)
 
             # create the plots
@@ -461,7 +460,6 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
                         xlabel=self.axes_labels[0],
                         ylabel=self.axes_labels[1],
                         title=f"{self.title}\nTask: {t_label}",
-                        # stat_caption=stat_caption,
                         stat_dict=stat_dict,
                         pXC50=self.pXC50,
                         min_val=self.min_val,
@@ -504,7 +502,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
                                   task_name=t_label,
                                   metric_names=self.metric_names,
                                   metrics=self._metrics,
-                                  bootstrap_confidence_level=self.confidence_level,
+                                  confidence_level=self.confidence_level,
                                   evaluated=self._evaluated,
                                   cv=True)
 
@@ -513,6 +511,6 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
                                task_name=t_label,
                                metric_names=self.metric_names,
                                metrics=self._metrics,
-                               bootstrap_confidence_level=self.confidence_level,
+                               confidence_level=self.confidence_level,
                                evaluated=self._evaluated,
                                cv=True)

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -204,7 +204,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
                                   bootstrap_confidence_level=self.confidence_level,
                                   evaluated=self._evaluated,
                                   cv=True)
-    
+
     def get_stat_dict(self, t_label):
         return _make_stat_dict(data=self.data,
                                task_name=t_label,
@@ -507,7 +507,7 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
                                   bootstrap_confidence_level=self.confidence_level,
                                   evaluated=self._evaluated,
                                   cv=True)
-    
+
     def get_stat_dict(self, t_label):
         return _make_stat_dict(data=self.data,
                                task_name=t_label,

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -172,6 +172,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
         self.plot_data = {}
 
         stat_caption = self.make_stat_caption(t_label)
+        stat_dict = self.make_stat_dict(t_label)
 
         # create the plots
         for plot_tag, plot in self.plots.items():
@@ -182,6 +183,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
                 ylabel=self.axes_labels[1],
                 title=f"{self.title}\nTask: {t_label}",
                 stat_caption=stat_caption,
+                stat_dict=stat_dict,
                 pXC50=self.pXC50,
                 min_val=self.min_val,
                 max_val=self.max_val,
@@ -208,6 +210,24 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
+    
+    def make_stat_dict(self, task_name):
+        if not self._evaluated:
+            raise ValueError("Must evaluate before making a caption")
+        
+        stat_dict = {}
+
+        stat_dict["task_name"] = task_name
+        for metric in self.metric_names:
+            value = self.data[task_name][metric]["mean"]
+            lower_ci = self.data[task_name][metric]["lower_ci"]
+            upper_ci = self.data[task_name][metric]["upper_ci"]
+            confidence_level = self.data[task_name][metric]["confidence_level"]
+
+            # Save in dict
+            stat_dict[self._metrics[metric][2]] = f"{value:.2f} [{lower_ci:.2f}, {upper_ci:.2f}]"
+        stat_dict["conf_level"] = confidence_level
+        return stat_dict
 
     def report(self, write=False, output_dir=None):
         """

--- a/openadmet/models/eval/cross_validation.py
+++ b/openadmet/models/eval/cross_validation.py
@@ -214,11 +214,11 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
-    
+
     def make_stat_dict(self, task_name):
         if not self._evaluated:
             raise ValueError("Must evaluate before making a caption")
-        
+
         stat_dict = {
             "metrics": [],
             "means": [],
@@ -227,7 +227,7 @@ class SKLearnRepeatedKFoldCrossValidation(CrossValidationBase):
             "conf_level": None,
             "task_name" : None
         }
-        
+
         stat_dict["task_name"] = task_name
 
         for metric in self.metric_names:
@@ -548,11 +548,11 @@ class PytorchLightningRepeatedKFoldCrossValidation(CrossValidationBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
-    
+
     def make_stat_dict(self, task_name):
         if not self._evaluated:
             raise ValueError("Must evaluate before making a caption")
-        
+
         stat_dict = {
             "metrics": [],
             "means": [],

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -182,11 +182,11 @@ class RegressionMetrics(EvalBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
-    
+
     def make_stat_dict(self):
         if not self._evaluated:
             raise ValueError("Must evaluate before making a caption")
-        
+
         stat_dict = {
             "metrics": [],
             "means": [],
@@ -342,14 +342,14 @@ class RegressionPlots(EvalBase):
         # set the limits to be the same for both axes
 
         g = sns.jointplot(
-            x=np.ravel(y_true), 
-            y=np.ravel(y_pred), 
-            kind="reg", 
-            joint_kws={"ci": confidence_level * 100}, 
-            scatter_kws={"alpha":0.3}, 
+            x=np.ravel(y_true),
+            y=np.ravel(y_pred),
+            kind="reg",
+            joint_kws={"ci": confidence_level * 100},
+            scatter_kws={"alpha":0.3},
             color="teal",
             height=10)
-        
+
         g.figure.suptitle(title, fontsize=title_font)
         g.ax_joint.set_aspect("equal", "box")
         g.ax_joint.set_xlim(min_ax, max_ax)
@@ -407,7 +407,7 @@ class RegressionPlots(EvalBase):
             # Right align the metric values
             for i in range(1, len(table_data) + 1):
                 table[i, 1].get_text().set_horizontalalignment("right")
-        
+
         g.ax_joint.set_box_aspect(1)
         g.figure.tight_layout()
         return g

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -353,7 +353,7 @@ class RegressionPlots(EvalBase):
                 else:
                     val_str = "N/A"
                 table_data.append([name, val_str])
-            # Create the table 
+            # Create the table
             table = g.ax_joint.table(
                 cellText=table_data,
                 colLabels=["Metric", f"Value ± {int(conf_level*100)}% CI"],

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -187,12 +187,21 @@ class RegressionMetrics(EvalBase):
         if not self._evaluated:
             raise ValueError("Must evaluate before making a caption")
         
-        stat_dict = {}
+        stat_dict = {
+            "metrics": [],
+            "means": [],
+            "lower_ci": [],
+            "upper_ci": [],
+            "conf_level": None,
+            "task_name" : None
+        }
 
         for task_name in self.task_names:
             if task_name == "tag":
                 continue
+
         stat_dict["task_name"] = task_name
+
         for metric in self.metric_names:
             value = self.data[task_name][metric]["value"]
             lower_ci = self.data[task_name][metric]["lower_ci"]
@@ -200,8 +209,11 @@ class RegressionMetrics(EvalBase):
             confidence_level = self.data[task_name][metric]["confidence_level"]
 
             # Save in dict
-            stat_dict[self._metrics[metric][2]] = f"{value:.2f} [{lower_ci:.2f}, {upper_ci:.2f}]"
-        stat_dict["conf_level"] = confidence_level
+            stat_dict["metrics"].append(self._metrics[metric][2])
+            stat_dict["means"].append(float(value))
+            stat_dict["lower_ci"].append(float(lower_ci))
+            stat_dict["upper_ci"].append(float(upper_ci))
+            stat_dict["conf_level"] = confidence_level
         return stat_dict
 
 
@@ -253,6 +265,7 @@ class RegressionPlots(EvalBase):
 
         self.plots = {
             "regplot": self.regplot,
+            "ciplot": self.ciplot
         }
 
         self.plot_data = {}
@@ -271,25 +284,29 @@ class RegressionPlots(EvalBase):
                     t_pred.reshape(-1, 1),
                     target_labels=[t_label],
                 )
-                stat_caption = rm.make_stat_caption()
+                # stat_caption = rm.make_stat_caption()
                 stat_dict = rm.make_stat_dict()
             else:
-                stat_caption = ""
+                # stat_caption = ""
+                stat_dict = {}
 
             # create the plots
             for plot_tag, plot in self.plots.items():
-                self.plot_data[t_label] = plot(
-                    t_true,
-                    t_pred,
-                    xlabel=self.axes_labels[0],
-                    ylabel=self.axes_labels[1],
-                    title=f"{self.title}\nTask: {t_label}",
-                    stat_caption=stat_caption,
-                    stat_dict=stat_dict,
-                    pXC50=self.pXC50,
-                    min_val=self.min_val,
-                    max_val=self.max_val,
-                )
+                if plot_tag == "ciplot":
+                    self.plot_data[f"{t_label}_{plot_tag}"] = plot(stat_dict=stat_dict)
+                else:
+                    self.plot_data[f"{t_label}_{plot_tag}"] = plot(
+                        t_true,
+                        t_pred,
+                        xlabel=self.axes_labels[0],
+                        ylabel=self.axes_labels[1],
+                        title=f"{self.title}\nTask: {t_label}",
+                        # stat_caption=stat_caption,
+                        stat_dict=stat_dict,
+                        pXC50=self.pXC50,
+                        min_val=self.min_val,
+                        max_val=self.max_val,
+                    )
         return self.plot_data
 
     @staticmethod
@@ -299,7 +316,7 @@ class RegressionPlots(EvalBase):
         xlabel="Measured",
         ylabel="Predicted",
         title="",
-        stat_caption="",
+        # stat_caption="",
         stat_dict={},
         confidence_level=0.95,
         pXC50=False,
@@ -309,8 +326,9 @@ class RegressionPlots(EvalBase):
         """
         Create a regression plot
         """
-        fig, ax = plt.subplots(figsize=(12,8))
-        ax.set_title(title, fontsize=20)
+        title_font = 20
+        ax_font = 18
+        tick_font = 16
         if min_val is None:
             min_val = min(np.min(y_true), np.min(y_pred))
             min_ax = min_val - 1
@@ -323,72 +341,125 @@ class RegressionPlots(EvalBase):
             max_ax = max_val
         # set the limits to be the same for both axes
 
-        _ = sns.regplot(x=y_true, y=y_pred, ax=ax, ci=confidence_level * 100, scatter_kws={"alpha":0.3}, color="teal")
-
-        # slope, intercept, r, p, sterr = scipy.stats.linregress(
-        #     x=p.get_lines()[0].get_xdata(), y=p.get_lines()[0].get_ydata()
-        # )
-        ax.set_aspect("equal", "box")
-
-        ax.set_xlim(min_ax, max_ax)
-        ax.set_ylim(min_ax, max_ax)
+        g = sns.jointplot(
+            x=np.ravel(y_true), 
+            y=np.ravel(y_pred), 
+            kind="reg", 
+            joint_kws={"ci": confidence_level * 100}, 
+            scatter_kws={"alpha":0.3}, 
+            color="teal",
+            height=10)
+        
+        g.figure.suptitle(title, fontsize=title_font)
+        g.ax_joint.set_aspect("equal", "box")
+        g.ax_joint.set_xlim(min_ax, max_ax)
+        g.ax_joint.set_ylim(min_ax, max_ax)
+        g.ax_joint.tick_params(axis='both', labelsize=tick_font)
         # plot y = x line in dashed grey
-        ax.plot([min_ax, max_ax], [min_ax, max_ax], linestyle="--", color="black")
+        g.ax_joint.plot([min_ax, max_ax], [min_ax, max_ax], linestyle="--", color="black")
 
         # if pXC50 measure then plot the 0.5 and 1.0 log range unit
         if pXC50:
-            ax.fill_between(
+            g.ax_joint.fill_between(
                 [min_ax, max_ax],
                 [min_ax - 0.5, max_ax - 0.5],
                 [min_ax + 0.5, max_ax + 0.5],
                 color="gray",
                 alpha=0.2,
             )
-            ax.fill_between(
+            g.ax_joint.fill_between(
                 [min_ax, max_ax],
                 [min_ax - 1, max_ax - 1],
                 [min_ax + 1, max_ax + 1],
                 color="gray",
                 alpha=0.2,
             )
-        ax.set_xlabel(xlabel, fontsize=18)
-        ax.set_ylabel(ylabel, fontsize=18)
+        g.ax_joint.set_xlabel(xlabel, fontsize=ax_font)
+        g.ax_joint.set_ylabel(ylabel, fontsize=ax_font)
 
         if stat_dict:
-            task_name = stat_dict.get("task_name", "Task")
             conf_level = stat_dict.get("conf_level", None)
-            metrics = {k: v for k, v in stat_dict.items() if k not in ['task_name', 'conf_level']}
-            table_data = [[k, v] for k, v in metrics.items()]
+            metric_names = stat_dict.get("metrics", [])
+            values = stat_dict.get("means", [])
+            lower_bounds = stat_dict.get("lower_ci", [])
+            upper_bounds = stat_dict.get("upper_ci", [])
 
-            if conf_level is not None:
-                table_data.append(["*", f"Values shown with {int(conf_level * 100)}% confidence"])
+            table_data = []
 
-            bbox = [1.05, 0.2, 1, 0.6]
+            for name, val, low, high in zip(metric_names, values, lower_bounds, upper_bounds):
+                if None not in (val, low, high):
+                    val_str = f"{val:.2f} [{low:.2f}, {high:.2f}]"
+                else:
+                    val_str = "N/A"
+                table_data.append([name, val_str])
 
-            table = ax.table(
+            table = g.ax_joint.table(
                 cellText=table_data,
-                colLabels=["Metric", "Value"],
-                colWidths=[0.3, 0.5],
+                colLabels=["Metric", f"Value ± {int(conf_level*100)}% CI"],
+                colWidths=[0.2, 0.3],
                 loc="upper left",
                 cellLoc="left",
-                bbox=bbox,
             )
 
-            ax.text(
-                bbox[0],
-                bbox[1] + bbox[3] + 0.02, 
-                f"Evaluation for {task_name}",
-                transform=ax.transAxes,
-                fontsize=16,
-                fontweight="bold",
-            )
-
+            table.scale(1, 1.8)
+            for key, cell in table.get_celld().items():
+                cell.set_fontsize(ax_font)
+            # Right align the metric values
             for i in range(1, len(table_data) + 1):
                 table[i, 1].get_text().set_horizontalalignment("right")
-        else:
-            ax.text(0.05, 0.7, stat_caption, transform=ax.transAxes, fontsize=5)
-        fig.tight_layout()
+        
+        g.ax_joint.set_box_aspect(1)
+        g.figure.tight_layout()
+        return g
 
+    @staticmethod
+    def ciplot(
+        stat_dict={}
+    ):
+
+        metrics = stat_dict["metrics"]
+        means = stat_dict["means"]
+        lower_ci = stat_dict["lower_ci"]
+        upper_ci = stat_dict["upper_ci"]
+        conf_level = stat_dict["conf_level"]
+        task_name = stat_dict["task_name"]
+
+        title_font = 16
+        tick_font = 12
+        ax_font = 14
+
+        padding = 0.2
+        y_limits = {
+            "MSE": (0-padding, 1+padding),
+            "MAE": (0-padding, 1+padding),
+            "$R^2$": (-1-padding, 1+padding),
+            "Kendall's $\\tau$": (-1-padding, 1+padding),
+            "Spearman's $\\rho$": (-1-padding, 1+padding)
+        }
+
+        n_metrics = len(metrics)
+        fig, axes = plt.subplots(1, n_metrics, figsize=(8, n_metrics), sharex=False)
+
+        if n_metrics == 1:
+            axes = [axes]  # Ensure it's iterable
+
+        for i, ax in enumerate(axes):
+            if i == 0:
+                ax.set_ylabel("Performance Metric Value", fontsize=ax_font)
+            metric = metrics[i]
+            y = means[i]
+            yerr = [[y - lower_ci[i]], [upper_ci[i] - y]]
+            ax.errorbar([metric], [y], yerr=yerr, fmt='o', capsize=8, color='green')
+            ax.tick_params(axis='both', labelsize=tick_font)
+            ax.yaxis.grid(True, linestyle='--', color='lightgray', alpha=0.6)
+            ax.set_xlim(-0.5, 0.5)
+
+            # Set fixed y-limits
+            if metric in y_limits:
+                ax.set_ylim(y_limits[metric])
+
+        fig.suptitle(f"Evaluation of {task_name} with {int(conf_level * 100)}% Confidence Intervals", fontsize=title_font)
+        fig.tight_layout()
         return fig
 
     def report(self, write=False, output_dir=None):

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -11,6 +11,7 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
 from openadmet.models.eval.eval_base import EvalBase, evaluators, mask_nans
+from openadmet.models.eval.utils import _make_stat_caption, _make_stat_dict
 
 # create partial functions for the scipy stats
 nan_omit_ktau = partial(kendalltau, nan_policy="omit")
@@ -159,63 +160,24 @@ class RegressionMetrics(EvalBase):
             artifact.add_file(json_path)
             # Log the artifact
             wandb.log_artifact(artifact)
-
-    def make_stat_caption(self):
-        """
-        Make a caption for the statistics
-        """
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-        stat_caption = ""
-
-        for task_name in self.task_names:
-            if task_name == "tag":
-                continue
-
-            stat_caption += f"## {task_name} ##\n"
-            for metric in self.metric_names:
-                value = self.data[task_name][metric]["value"]
-                lower_ci = self.data[task_name][metric]["lower_ci"]
-                upper_ci = self.data[task_name][metric]["upper_ci"]
-                confidence_level = self.data[task_name][metric]["confidence_level"]
-                stat_caption += f"{self._metrics[metric][2]}: {value:.2f}$_{{{lower_ci:.2f}}}^{{{upper_ci:.2f}}}$\n"
-            stat_caption += "\n"
-        stat_caption += f"Confidence level: {confidence_level} \n"
-        return stat_caption
-
-    def make_stat_dict(self):
-        if not self._evaluated:
-            raise ValueError("Must evaluate before making a caption")
-
-        stat_dict = {
-            "metrics": [],
-            "means": [],
-            "lower_ci": [],
-            "upper_ci": [],
-            "conf_level": None,
-            "task_name" : None
-        }
-
-        for task_name in self.task_names:
-            if task_name == "tag":
-                continue
-
-        stat_dict["task_name"] = task_name
-
-        for metric in self.metric_names:
-            value = self.data[task_name][metric]["value"]
-            lower_ci = self.data[task_name][metric]["lower_ci"]
-            upper_ci = self.data[task_name][metric]["upper_ci"]
-            confidence_level = self.data[task_name][metric]["confidence_level"]
-
-            # Save in dict
-            stat_dict["metrics"].append(self._metrics[metric][2])
-            stat_dict["means"].append(float(value))
-            stat_dict["lower_ci"].append(float(lower_ci))
-            stat_dict["upper_ci"].append(float(upper_ci))
-            stat_dict["conf_level"] = confidence_level
-        return stat_dict
-
+    
+    def get_stat_caption(self, t_label):
+        return _make_stat_caption(data=self.data,
+                                  task_name=t_label,
+                                  metric_names=self.metric_names,
+                                  metrics=self._metrics,
+                                  bootstrap_confidence_level=self.bootstrap_confidence_level,
+                                  evaluated=self._evaluated,
+                                  cv=False)
+    
+    def get_stat_dict(self, t_label):
+        return _make_stat_dict(data=self.data,
+                               task_name=t_label,
+                               metric_names=self.metric_names,
+                               metrics=self._metrics,
+                               bootstrap_confidence_level=self.bootstrap_confidence_level,
+                               evaluated=self._evaluated,
+                               cv=False)
 
 
 
@@ -285,16 +247,16 @@ class RegressionPlots(EvalBase):
                     target_labels=[t_label],
                 )
                 # stat_caption = rm.make_stat_caption()
-                stat_dict = rm.make_stat_dict()
+                stat_dict = rm.get_stat_dict(t_label=t_label)
             else:
                 # stat_caption = ""
                 stat_dict = {}
 
             # create the plots
             for plot_tag, plot in self.plots.items():
-                if plot_tag == "ciplot":
+                if "ciplot" in plot_tag:
                     self.plot_data[f"{t_label}_{plot_tag}"] = plot(stat_dict=stat_dict)
-                else:
+                elif "regplot" in plot_tag:
                     self.plot_data[f"{t_label}_{plot_tag}"] = plot(
                         t_true,
                         t_pred,

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -182,6 +182,29 @@ class RegressionMetrics(EvalBase):
             stat_caption += "\n"
         stat_caption += f"Confidence level: {confidence_level} \n"
         return stat_caption
+    
+    def make_stat_dict(self):
+        if not self._evaluated:
+            raise ValueError("Must evaluate before making a caption")
+        
+        stat_dict = {}
+
+        for task_name in self.task_names:
+            if task_name == "tag":
+                continue
+        stat_dict["task_name"] = task_name
+        for metric in self.metric_names:
+            value = self.data[task_name][metric]["value"]
+            lower_ci = self.data[task_name][metric]["lower_ci"]
+            upper_ci = self.data[task_name][metric]["upper_ci"]
+            confidence_level = self.data[task_name][metric]["confidence_level"]
+
+            # Save in dict
+            stat_dict[self._metrics[metric][2]] = f"{value:.2f} [{lower_ci:.2f}, {upper_ci:.2f}]"
+        stat_dict["conf_level"] = confidence_level
+        return stat_dict
+
+
 
 
 @evaluators.register("RegressionPlots")
@@ -249,6 +272,7 @@ class RegressionPlots(EvalBase):
                     target_labels=[t_label],
                 )
                 stat_caption = rm.make_stat_caption()
+                stat_dict = rm.make_stat_dict()
             else:
                 stat_caption = ""
 
@@ -261,6 +285,7 @@ class RegressionPlots(EvalBase):
                     ylabel=self.axes_labels[1],
                     title=f"{self.title}\nTask: {t_label}",
                     stat_caption=stat_caption,
+                    stat_dict=stat_dict,
                     pXC50=self.pXC50,
                     min_val=self.min_val,
                     max_val=self.max_val,
@@ -275,6 +300,7 @@ class RegressionPlots(EvalBase):
         ylabel="Predicted",
         title="",
         stat_caption="",
+        stat_dict={},
         confidence_level=0.95,
         pXC50=False,
         min_val=None,
@@ -283,8 +309,8 @@ class RegressionPlots(EvalBase):
         """
         Create a regression plot
         """
-        fig, ax = plt.subplots()
-        ax.set_title(title, fontsize=10)
+        fig, ax = plt.subplots(figsize=(12,8))
+        ax.set_title(title, fontsize=20)
         if min_val is None:
             min_val = min(np.min(y_true), np.min(y_pred))
             min_ax = min_val - 1
@@ -296,7 +322,9 @@ class RegressionPlots(EvalBase):
         else:
             max_ax = max_val
         # set the limits to be the same for both axes
-        _ = sns.regplot(x=y_true, y=y_pred, ax=ax, ci=confidence_level * 100)
+
+        _ = sns.regplot(x=y_true, y=y_pred, ax=ax, ci=confidence_level * 100, scatter_kws={"alpha":0.3}, color="teal")
+
         # slope, intercept, r, p, sterr = scipy.stats.linregress(
         #     x=p.get_lines()[0].get_xdata(), y=p.get_lines()[0].get_ydata()
         # )
@@ -323,9 +351,42 @@ class RegressionPlots(EvalBase):
                 color="gray",
                 alpha=0.2,
             )
-        ax.set_xlabel(xlabel, fontsize=10)
-        ax.set_ylabel(ylabel, fontsize=10)
-        ax.text(0.05, 0.7, stat_caption, transform=ax.transAxes, fontsize=5)
+        ax.set_xlabel(xlabel, fontsize=18)
+        ax.set_ylabel(ylabel, fontsize=18)
+
+        if stat_dict:
+            task_name = stat_dict.get("task_name", "Task")
+            conf_level = stat_dict.get("conf_level", None)
+            metrics = {k: v for k, v in stat_dict.items() if k not in ['task_name', 'conf_level']}
+            table_data = [[k, v] for k, v in metrics.items()]
+
+            if conf_level is not None:
+                table_data.append(["*", f"Values shown with {int(conf_level * 100)}% confidence"])
+
+            bbox = [1.05, 0.2, 1, 0.6]
+
+            table = ax.table(
+                cellText=table_data,
+                colLabels=["Metric", "Value"],
+                colWidths=[0.3, 0.5],
+                loc="upper left",
+                cellLoc="left",
+                bbox=bbox,
+            )
+
+            ax.text(
+                bbox[0],
+                bbox[1] + bbox[3] + 0.02, 
+                f"Evaluation for {task_name}",
+                transform=ax.transAxes,
+                fontsize=16,
+                fontweight="bold",
+            )
+
+            for i in range(1, len(table_data) + 1):
+                table[i, 1].get_text().set_horizontalalignment("right")
+        else:
+            ax.text(0.05, 0.7, stat_caption, transform=ax.transAxes, fontsize=5)
         fig.tight_layout()
 
         return fig

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -162,21 +162,23 @@ class RegressionMetrics(EvalBase):
             wandb.log_artifact(artifact)
 
     def get_stat_caption(self, t_label):
+        if not self._evaluated:
+            raise ValueError(":( You must evaluate the model before the statistics caption can be made.")
         return _make_stat_caption(data=self.data,
                                   task_name=t_label,
                                   metric_names=self.metric_names,
                                   metrics=self._metrics,
-                                  bootstrap_confidence_level=self.bootstrap_confidence_level,
-                                  evaluated=self._evaluated,
+                                  confidence_level=self.bootstrap_confidence_level,
                                   cv=False)
 
     def get_stat_dict(self, t_label):
+        if not self._evaluated:
+            raise ValueError("R'uh-r'oh! You must evaluate the model before the statistics dict can be made.")
         return _make_stat_dict(data=self.data,
                                task_name=t_label,
                                metric_names=self.metric_names,
                                metrics=self._metrics,
-                               bootstrap_confidence_level=self.bootstrap_confidence_level,
-                               evaluated=self._evaluated,
+                               confidence_level=self.bootstrap_confidence_level,
                                cv=False)
 
 
@@ -246,10 +248,8 @@ class RegressionPlots(EvalBase):
                     t_pred.reshape(-1, 1),
                     target_labels=[t_label],
                 )
-                # stat_caption = rm.make_stat_caption()
                 stat_dict = rm.get_stat_dict(t_label=t_label)
             else:
-                # stat_caption = ""
                 stat_dict = {}
 
             # create the plots
@@ -263,7 +263,6 @@ class RegressionPlots(EvalBase):
                         xlabel=self.axes_labels[0],
                         ylabel=self.axes_labels[1],
                         title=f"{self.title}\nTask: {t_label}",
-                        # stat_caption=stat_caption,
                         stat_dict=stat_dict,
                         pXC50=self.pXC50,
                         min_val=self.min_val,
@@ -278,7 +277,6 @@ class RegressionPlots(EvalBase):
         xlabel="Measured",
         ylabel="Predicted",
         title="",
-        # stat_caption="",
         stat_dict={},
         confidence_level=0.95,
         pXC50=False,
@@ -339,6 +337,7 @@ class RegressionPlots(EvalBase):
         g.ax_joint.set_xlabel(xlabel, fontsize=ax_font)
         g.ax_joint.set_ylabel(ylabel, fontsize=ax_font)
 
+        # From the stat_dict, parse out the performance metric values and their labels to put into a table to print on the regression plot
         if stat_dict:
             conf_level = stat_dict.get("conf_level", None)
             metric_names = stat_dict.get("metrics", [])
@@ -347,14 +346,14 @@ class RegressionPlots(EvalBase):
             upper_bounds = stat_dict.get("upper_ci", [])
 
             table_data = []
-
+            # Format the metric values for readability
             for name, val, low, high in zip(metric_names, values, lower_bounds, upper_bounds):
                 if None not in (val, low, high):
                     val_str = f"{val:.2f} [{low:.2f}, {high:.2f}]"
                 else:
                     val_str = "N/A"
                 table_data.append([name, val_str])
-
+            # Create the table 
             table = g.ax_joint.table(
                 cellText=table_data,
                 colLabels=["Metric", f"Value ± {int(conf_level*100)}% CI"],

--- a/openadmet/models/eval/regression.py
+++ b/openadmet/models/eval/regression.py
@@ -160,7 +160,7 @@ class RegressionMetrics(EvalBase):
             artifact.add_file(json_path)
             # Log the artifact
             wandb.log_artifact(artifact)
-    
+
     def get_stat_caption(self, t_label):
         return _make_stat_caption(data=self.data,
                                   task_name=t_label,
@@ -169,7 +169,7 @@ class RegressionMetrics(EvalBase):
                                   bootstrap_confidence_level=self.bootstrap_confidence_level,
                                   evaluated=self._evaluated,
                                   cv=False)
-    
+
     def get_stat_dict(self, t_label):
         return _make_stat_dict(data=self.data,
                                task_name=t_label,

--- a/openadmet/models/eval/utils.py
+++ b/openadmet/models/eval/utils.py
@@ -3,8 +3,7 @@ def _make_stat_caption(
         task_name:str,
         metric_names:list,
         metrics:dict,
-        bootstrap_confidence_level:float,
-        evaluated:bool,
+        confidence_level:float,
         cv:bool
 ) -> str:
     """A function to generate the stat caption (string) to be printed on the regplot
@@ -19,10 +18,8 @@ def _make_stat_caption(
         a dict of the names of the metrics
     metrics : dict
         a dict of tuples of (metric value, whether the value is a scipy statistic, name of metric to use in the report)
-    bootstrap_confidence_level : float
+    confidence_level : float
         conficence level for the bootstrap
-    evaluated : bool
-        whether or not the model has been evaluated
     cv : bool
         whether or not you are doing cross validation for evaluation
 
@@ -36,8 +33,6 @@ def _make_stat_caption(
     ValueError
         cannot make stat caption unless the model has been evaluated first
     """
-    if not evaluated:
-        raise ValueError("Must evaluate before making a caption")
     stat_caption = ""
 
     value_key = "mean" if cv else "value"
@@ -47,10 +42,9 @@ def _make_stat_caption(
         value = data[task_name][metric][value_key]
         lower_ci = data[task_name][metric]["lower_ci"]
         upper_ci = data[task_name][metric]["upper_ci"]
-        # confidence_level = data[task_name][metric]["confidence_level"]
         stat_caption += f"{metrics[metric][2]}: {value:.2f}$_{{{lower_ci:.2f}}}^{{{upper_ci:.2f}}}$\n"
     stat_caption += "\n"
-    stat_caption += f"Confidence level: {bootstrap_confidence_level} \n"
+    stat_caption += f"Confidence level: {confidence_level} \n"
     return stat_caption
 
 def _make_stat_dict(
@@ -58,8 +52,7 @@ def _make_stat_dict(
         task_name:str,
         metric_names:list,
         metrics:dict,
-        bootstrap_confidence_level:float,
-        evaluated:bool,
+        confidence_level:float,
         cv:bool
 ):
     """A function to generate a dict of formatted metrics and names to be printed into a table on regplot
@@ -74,8 +67,6 @@ def _make_stat_dict(
         a dict of the names of the metrics
     metrics : dict
         a dict of tuples of (metric value, whether the value is a scipy statistic, name of metric to use in the report)
-    bootstrap_confidence_level : float
-        conficence level for the bootstrap
     evaluated : bool
         whether or not the model has been evaluated
 
@@ -89,8 +80,6 @@ def _make_stat_dict(
     ValueError
         cannot make stat caption unless the model has been evaluated first
     """
-    if not evaluated:
-        raise ValueError("Must evaluate before making a caption")
 
     stat_dict = {
         "metrics": [],
@@ -107,12 +96,11 @@ def _make_stat_dict(
         value = data[task_name][metric][value_key]
         lower_ci = data[task_name][metric]["lower_ci"]
         upper_ci = data[task_name][metric]["upper_ci"]
-        # confidence_level = data[task_name][metric]["confidence_level"]
 
         # Save in dict
         stat_dict["metrics"].append(metrics[metric][2])
         stat_dict["means"].append(float(value))
         stat_dict["lower_ci"].append(float(lower_ci))
         stat_dict["upper_ci"].append(float(upper_ci))
-        stat_dict["conf_level"] = bootstrap_confidence_level
+        stat_dict["conf_level"] = confidence_level
     return stat_dict

--- a/openadmet/models/eval/utils.py
+++ b/openadmet/models/eval/utils.py
@@ -1,5 +1,3 @@
-
-
 def _make_stat_caption(
         data:dict,
         task_name:str,

--- a/openadmet/models/eval/utils.py
+++ b/openadmet/models/eval/utils.py
@@ -1,0 +1,120 @@
+
+
+def _make_stat_caption(
+        data:dict,
+        task_name:str,
+        metric_names:list,
+        metrics:dict,
+        bootstrap_confidence_level:float,
+        evaluated:bool,
+        cv:bool
+) -> str:
+    """A function to generate the stat caption (string) to be printed on the regplot
+
+    Parameters
+    ----------
+    data : dict
+        a dict of task_names, metric_names, metrics, bootstrap_confidence_level, evaluated parameters filled out after evaluating the regression model
+    task_names : list or str
+        a list of all the tasks, i.e. the predicted target columns, OR str for single task
+    metric_names : dict
+        a dict of the names of the metrics
+    metrics : dict
+        a dict of tuples of (metric value, whether the value is a scipy statistic, name of metric to use in the report)
+    bootstrap_confidence_level : float
+        conficence level for the bootstrap
+    evaluated : bool
+        whether or not the model has been evaluated
+    cv : bool
+        whether or not you are doing cross validation for evaluation
+
+    Returns
+    -------
+    str
+        a string containing all the formatted metrics and their labels to be printed on a plot
+
+    Raises
+    ------
+    ValueError
+        cannot make stat caption unless the model has been evaluated first
+    """
+    if not evaluated:
+        raise ValueError("Must evaluate before making a caption")
+    stat_caption = ""
+
+    value_key = "mean" if cv else "value"
+
+    stat_caption += f"## {task_name} ##\n"
+    for metric in metric_names:
+        value = data[task_name][metric][value_key]
+        lower_ci = data[task_name][metric]["lower_ci"]
+        upper_ci = data[task_name][metric]["upper_ci"]
+        # confidence_level = data[task_name][metric]["confidence_level"]
+        stat_caption += f"{metrics[metric][2]}: {value:.2f}$_{{{lower_ci:.2f}}}^{{{upper_ci:.2f}}}$\n"
+    stat_caption += "\n"
+    stat_caption += f"Confidence level: {bootstrap_confidence_level} \n"
+    return stat_caption
+
+def _make_stat_dict(
+        data:dict,
+        task_name:str,
+        metric_names:list,
+        metrics:dict,
+        bootstrap_confidence_level:float,
+        evaluated:bool,
+        cv:bool
+):
+    """A function to generate a dict of formatted metrics and names to be printed into a table on regplot
+
+    Parameters
+    ----------
+    data : dict
+        a dict of task_names, metric_names, metrics, bootstrap_confidence_level, evaluated parameters filled out after evaluating the regression model
+    task_names : list or str
+        a list of all the tasks, i.e. the predicted target columns, OR str for single task
+    metric_names : dict
+        a dict of the names of the metrics
+    metrics : dict
+        a dict of tuples of (metric value, whether the value is a scipy statistic, name of metric to use in the report)
+    bootstrap_confidence_level : float
+        conficence level for the bootstrap
+    evaluated : bool
+        whether or not the model has been evaluated
+
+    Returns
+    -------
+    dict
+        a dict containing all the formatted metrics and their labels to be printed on a plot
+
+    Raises
+    ------
+    ValueError
+        cannot make stat caption unless the model has been evaluated first
+    """
+    if not evaluated:
+        raise ValueError("Must evaluate before making a caption")
+
+    stat_dict = {
+        "metrics": [],
+        "means": [],
+        "lower_ci": [],
+        "upper_ci": [],
+        "conf_level": None,
+        "task_name" : task_name
+    }
+
+    value_key = "mean" if cv else "value"
+
+    for metric in metric_names:
+        value = data[task_name][metric][value_key]
+        lower_ci = data[task_name][metric]["lower_ci"]
+        upper_ci = data[task_name][metric]["upper_ci"]
+        # confidence_level = data[task_name][metric]["confidence_level"]
+
+        # Save in dict
+        stat_dict["metrics"].append(metrics[metric][2])
+        stat_dict["means"].append(float(value))
+        stat_dict["lower_ci"].append(float(lower_ci))
+        stat_dict["upper_ci"].append(float(upper_ci))
+        stat_dict["conf_level"] = bootstrap_confidence_level
+    return stat_dict


### PR DESCRIPTION
## Description
- partially addresses #218 
- makes final regplot figure larger
- adds density to regplot in the form of histograms (kdeplot is not possible because of an error in an older version of seaborn, but tabfpn requires that older version of seaborn, so this is a workaround); Closes #201 
- adds `ciplot` which plots the regression metrics with confidence intervals as error bars; exports as `cross_validation_ciplot.png`
- error bars from experimental error feature still needs to be added #200

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go
