### PR TITLE
Split into train+val and test, then train, val, and test

### DIFF
--- a/openadmet/models/split/scaffold.py
+++ b/openadmet/models/split/scaffold.py
@@ -13,57 +13,61 @@ class ScaffoldSplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
-        # First split into train and val+test
+        # No test nor validation set requested, return the entire dataset as train
+        if self.test_size == 0 and self.val_size == 0:
+            return X, None, None, y, None, None
+
+        # Split into train+val and test
         splitter = ScaffoldSplit(
             smiles=X,
             n_jobs=-1,
             train_size=None,
-            test_size=int((self.test_size + self.val_size) * X.shape[0]),
+            test_size=int(self.test_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_test_idx = next(splitter.split(X=X))
+        train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # If no validation set is requested, return train and test sets
+        # No validation set requested, return train+val and test sets
         if self.val_size == 0:
             return (
-                X[train_idx],
+                X[train_val_idx],
                 None,
-                X[val_test_idx],
-                y[train_idx],
+                X[test_idx],
+                y[train_val_idx],
                 None,
-                y[val_test_idx],
+                y[test_idx],
             )
 
-        # If no test set is requested, return train and validation sets
-        elif self.test_size == 0:
-            return (
-                X[train_idx],
-                X[val_test_idx],
-                None,
-                y[train_idx],
-                y[val_test_idx],
-                None,
-            )
+        # Split train+val into train and validation sets
+        val_splitter = ScaffoldSplit(
+            smiles=X[train_val_idx],
+            n_jobs=-1,
+            train_size=None,
+            test_size=int(self.val_size * X.shape[0]),
+            random_state=self.random_state,
+        )
+        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
-        # If both test and validation sets are requested, split the remaining data
-        else:
-            val_test_splitter = ScaffoldSplit(
-                smiles=X[val_test_idx],
-                n_jobs=-1,
-                train_size=None,
-                test_size=int(self.test_size * X.shape[0]),
-                random_state=self.random_state,
-            )
-            val_idx, test_idx = next(val_test_splitter.split(X=X[val_test_idx]))
-
+        # No test set requested, return train and validation sets
+        if self.test_size == 0:
             return (
                 X[train_idx],
                 X[val_idx],
-                X[test_idx],
+                None,
                 y[train_idx],
                 y[val_idx],
-                y[test_idx],
+                None,
             )
+
+        # Return train, validation and test sets
+        return (
+            X[train_idx],
+            X[val_idx],
+            X[test_idx],
+            y[train_idx],
+            y[val_idx],
+            y[test_idx],
+        )
 
 
 @splitters.register("PerimeterSplitter")
@@ -76,56 +80,59 @@ class PerimeterSplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
+        # No test nor validation set requested, return the entire dataset as train
+        if self.test_size == 0 and self.val_size == 0:
+            return X, None, None, y, None, None
 
-        # First split into train and val+test
+        # Split into train+val and test
         splitter = PerimeterSplit(
             n_jobs=-1,
             train_size=None,
-            test_size=int((self.test_size + self.val_size) * X.shape[0]),
+            test_size=int(self.test_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_test_idx = next(splitter.split(X=X))
+        train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # If no validation set is requested, return train and test sets
+        # No validation set requested, return train+val and test sets
         if self.val_size == 0:
             return (
-                X[train_idx],
+                X[train_val_idx],
                 None,
-                X[val_test_idx],
-                y[train_idx],
+                X[test_idx],
+                y[train_val_idx],
                 None,
-                y[val_test_idx],
+                y[test_idx],
             )
 
-        # If no test set is requested, return train and validation sets
-        elif self.test_size == 0:
-            return (
-                X[train_idx],
-                X[val_test_idx],
-                None,
-                y[train_idx],
-                y[val_test_idx],
-                None,
-            )
+        # Split train+val into train and validation sets
+        val_splitter = PerimeterSplit(
+            n_jobs=-1,
+            train_size=None,
+            test_size=int(self.val_size * X.shape[0]),
+            random_state=self.random_state,
+        )
+        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
-        # If both test and validation sets are requested, split the remaining data
-        else:
-            val_test_splitter = PerimeterSplit(
-                n_jobs=-1,
-                train_size=None,
-                test_size=int(self.test_size * X.shape[0]),
-                random_state=self.random_state,
-            )
-            val_idx, test_idx = next(val_test_splitter.split(X=X[val_test_idx]))
-
+        # No test set requested, return train and validation sets
+        if self.test_size == 0:
             return (
                 X[train_idx],
                 X[val_idx],
-                X[test_idx],
+                None,
                 y[train_idx],
                 y[val_idx],
-                y[test_idx],
+                None,
             )
+
+        # Return train, validation and test sets
+        return (
+            X[train_idx],
+            X[val_idx],
+            X[test_idx],
+            y[train_idx],
+            y[val_idx],
+            y[test_idx],
+        )
 
 
 @splitters.register("MaxDissimilaritySplitter")
@@ -138,53 +145,56 @@ class MaxDissimilaritySplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
+        # No test nor validation set requested, return the entire dataset as train
+        if self.test_size == 0 and self.val_size == 0:
+            return X, None, None, y, None, None
 
-        # First split into train and val+test
+        # Split into train+val and test
         splitter = MaxDissimilaritySplit(
             n_jobs=-1,
             train_size=None,
-            test_size=int((self.test_size + self.val_size) * X.shape[0]),
+            test_size=int(self.test_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_test_idx = next(splitter.split(X=X))
+        train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # If no validation set is requested, return train and test sets
+        # No validation set requested, return train+val and test sets
         if self.val_size == 0:
             return (
-                X[train_idx],
+                X[train_val_idx],
                 None,
-                X[val_test_idx],
-                y[train_idx],
+                X[test_idx],
+                y[train_val_idx],
                 None,
-                y[val_test_idx],
+                y[test_idx],
             )
 
-        # If no test set is requested, return train and validation sets
-        elif self.test_size == 0:
-            return (
-                X[train_idx],
-                X[val_test_idx],
-                None,
-                y[train_idx],
-                y[val_test_idx],
-                None,
-            )
+        # Split train+val into train and validation sets
+        val_splitter = MaxDissimilaritySplit(
+            n_jobs=-1,
+            train_size=None,
+            test_size=int(self.val_size * X.shape[0]),
+            random_state=self.random_state,
+        )
+        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
-        # If both test and validation sets are requested, split the remaining data
-        else:
-            val_test_splitter = MaxDissimilaritySplit(
-                n_jobs=-1,
-                train_size=None,
-                test_size=int(self.test_size * X.shape[0]),
-                random_state=self.random_state,
-            )
-            val_idx, test_idx = next(val_test_splitter.split(X=X[val_test_idx]))
-
+        # No test set requested, return train and validation sets
+        if self.test_size == 0:
             return (
                 X[train_idx],
                 X[val_idx],
-                X[test_idx],
+                None,
                 y[train_idx],
                 y[val_idx],
-                y[test_idx],
+                None,
             )
+
+        # Return train, validation and test sets
+        return (
+            X[train_idx],
+            X[val_idx],
+            X[test_idx],
+            y[train_idx],
+            y[val_idx],
+            y[test_idx],
+        )

--- a/openadmet/models/split/scaffold.py
+++ b/openadmet/models/split/scaffold.py
@@ -1,3 +1,4 @@
+from sklearn.model_selection import train_test_split
 from splito import MaxDissimilaritySplit, PerimeterSplit, ScaffoldSplit
 
 from openadmet.models.split.split_base import SplitterBase, splitters
@@ -39,33 +40,32 @@ class ScaffoldSplitter(SplitterBase):
             )
 
         # Split train+val into train and validation sets
-        val_splitter = ScaffoldSplit(
-            smiles=X[train_val_idx],
-            n_jobs=-1,
+        X_train, X_val, y_train, y_val = train_test_split(
+            X[train_val_idx],
+            y[train_val_idx],
             train_size=None,
             test_size=int(self.val_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
         # No test set requested, return train and validation sets
         if self.test_size == 0:
             return (
-                X[train_idx],
-                X[val_idx],
+                X_train,
+                X_val,
                 None,
-                y[train_idx],
-                y[val_idx],
+                y_train,
+                y_val,
                 None,
             )
 
         # Return train, validation and test sets
         return (
-            X[train_idx],
-            X[val_idx],
+            X_train,
+            X_val,
             X[test_idx],
-            y[train_idx],
-            y[val_idx],
+            y_train,
+            y_val,
             y[test_idx],
         )
 
@@ -104,33 +104,33 @@ class PerimeterSplitter(SplitterBase):
                 y[test_idx],
             )
 
-        # Split train+val into train and validation sets
-        val_splitter = PerimeterSplit(
-            n_jobs=-1,
+        # Split train+val into train and validation sets using sklearn
+        X_train, X_val, y_train, y_val = train_test_split(
+            X[train_val_idx],
+            y[train_val_idx],
             train_size=None,
             test_size=int(self.val_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
         # No test set requested, return train and validation sets
         if self.test_size == 0:
             return (
-                X[train_idx],
-                X[val_idx],
+                X_train,
+                X_val,
                 None,
-                y[train_idx],
-                y[val_idx],
+                y_train,
+                y_val,
                 None,
             )
 
         # Return train, validation and test sets
         return (
-            X[train_idx],
-            X[val_idx],
+            X_train,
+            X_val,
             X[test_idx],
-            y[train_idx],
-            y[val_idx],
+            y_train,
+            y_val,
             y[test_idx],
         )
 
@@ -169,32 +169,32 @@ class MaxDissimilaritySplitter(SplitterBase):
                 y[test_idx],
             )
 
-        # Split train+val into train and validation sets
-        val_splitter = MaxDissimilaritySplit(
-            n_jobs=-1,
+        # Split train+val into train and validation sets using sklearn
+        X_train, X_val, y_train, y_val = train_test_split(
+            X[train_val_idx],
+            y[train_val_idx],
             train_size=None,
             test_size=int(self.val_size * X.shape[0]),
             random_state=self.random_state,
         )
-        train_idx, val_idx = next(val_splitter.split(X=X[train_val_idx]))
 
         # No test set requested, return train and validation sets
         if self.test_size == 0:
             return (
-                X[train_idx],
-                X[val_idx],
+                X_train,
+                X_val,
                 None,
-                y[train_idx],
-                y[val_idx],
+                y_train,
+                y_val,
                 None,
             )
 
         # Return train, validation and test sets
         return (
-            X[train_idx],
-            X[val_idx],
+            X_train,
+            X_val,
             X[test_idx],
-            y[train_idx],
-            y[val_idx],
+            y_train,
+            y_val,
             y[test_idx],
         )

--- a/openadmet/models/split/scaffold.py
+++ b/openadmet/models/split/scaffold.py
@@ -14,9 +14,26 @@ class ScaffoldSplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
-        # No test nor validation set requested, return the entire dataset as train
-        if self.test_size == 0 and self.val_size == 0:
-            return X, None, None, y, None, None
+        # No test set requested
+        if self.test_size == 0:
+            # Split into train and val
+            splitter = ScaffoldSplit(
+                smiles=X,
+                n_jobs=-1,
+                train_size=None,
+                test_size=int(self.val_size * X.shape[0]),
+                random_state=self.random_state,
+            )
+            train_idx, val_idx = next(splitter.split(X=X))
+
+            return (
+                X[train_idx],
+                X[val_idx],
+                None,
+                y[train_idx],
+                y[val_idx],
+                None,
+            )
 
         # Split into train+val and test
         splitter = ScaffoldSplit(
@@ -28,7 +45,7 @@ class ScaffoldSplitter(SplitterBase):
         )
         train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # No validation set requested, return train+val and test sets
+        # No validation set requested, return train(+val) and test sets
         if self.val_size == 0:
             return (
                 X[train_val_idx],
@@ -39,7 +56,7 @@ class ScaffoldSplitter(SplitterBase):
                 y[test_idx],
             )
 
-        # Split train+val into train and validation sets
+        # Split train+val into train and val sets
         X_train, X_val, y_train, y_val = train_test_split(
             X[train_val_idx],
             y[train_val_idx],
@@ -48,18 +65,7 @@ class ScaffoldSplitter(SplitterBase):
             random_state=self.random_state,
         )
 
-        # No test set requested, return train and validation sets
-        if self.test_size == 0:
-            return (
-                X_train,
-                X_val,
-                None,
-                y_train,
-                y_val,
-                None,
-            )
-
-        # Return train, validation and test sets
+        # Return train, val, and test sets
         return (
             X_train,
             X_val,
@@ -80,9 +86,26 @@ class PerimeterSplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
-        # No test nor validation set requested, return the entire dataset as train
-        if self.test_size == 0 and self.val_size == 0:
-            return X, None, None, y, None, None
+        # No test set requested
+        if self.test_size == 0:
+            # Split into train and val
+            splitter = PerimeterSplit(
+                smiles=X,
+                n_jobs=-1,
+                train_size=None,
+                test_size=int(self.val_size * X.shape[0]),
+                random_state=self.random_state,
+            )
+            train_idx, val_idx = next(splitter.split(X=X))
+
+            return (
+                X[train_idx],
+                X[val_idx],
+                None,
+                y[train_idx],
+                y[val_idx],
+                None,
+            )
 
         # Split into train+val and test
         splitter = PerimeterSplit(
@@ -93,7 +116,7 @@ class PerimeterSplitter(SplitterBase):
         )
         train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # No validation set requested, return train+val and test sets
+        # No validation set requested, return train(+val) and test sets
         if self.val_size == 0:
             return (
                 X[train_val_idx],
@@ -104,7 +127,7 @@ class PerimeterSplitter(SplitterBase):
                 y[test_idx],
             )
 
-        # Split train+val into train and validation sets using sklearn
+        # Split train+val into train and val sets using sklearn
         X_train, X_val, y_train, y_val = train_test_split(
             X[train_val_idx],
             y[train_val_idx],
@@ -113,18 +136,7 @@ class PerimeterSplitter(SplitterBase):
             random_state=self.random_state,
         )
 
-        # No test set requested, return train and validation sets
-        if self.test_size == 0:
-            return (
-                X_train,
-                X_val,
-                None,
-                y_train,
-                y_val,
-                None,
-            )
-
-        # Return train, validation and test sets
+        # Return train, val, and test sets
         return (
             X_train,
             X_val,
@@ -145,9 +157,26 @@ class MaxDissimilaritySplitter(SplitterBase):
         """
         Split the data into train, validation, and test sets
         """
-        # No test nor validation set requested, return the entire dataset as train
-        if self.test_size == 0 and self.val_size == 0:
-            return X, None, None, y, None, None
+        # No test set requested
+        if self.test_size == 0:
+            # Split into train and val
+            splitter = MaxDissimilaritySplit(
+                smiles=X,
+                n_jobs=-1,
+                train_size=None,
+                test_size=int(self.val_size * X.shape[0]),
+                random_state=self.random_state,
+            )
+            train_idx, val_idx = next(splitter.split(X=X))
+
+            return (
+                X[train_idx],
+                X[val_idx],
+                None,
+                y[train_idx],
+                y[val_idx],
+                None,
+            )
 
         # Split into train+val and test
         splitter = MaxDissimilaritySplit(
@@ -158,7 +187,7 @@ class MaxDissimilaritySplitter(SplitterBase):
         )
         train_val_idx, test_idx = next(splitter.split(X=X))
 
-        # No validation set requested, return train+val and test sets
+        # No validation set requested, return train(+val) and test sets
         if self.val_size == 0:
             return (
                 X[train_val_idx],
@@ -169,7 +198,7 @@ class MaxDissimilaritySplitter(SplitterBase):
                 y[test_idx],
             )
 
-        # Split train+val into train and validation sets using sklearn
+        # Split train+val into train and val sets using sklearn
         X_train, X_val, y_train, y_val = train_test_split(
             X[train_val_idx],
             y[train_val_idx],
@@ -178,18 +207,7 @@ class MaxDissimilaritySplitter(SplitterBase):
             random_state=self.random_state,
         )
 
-        # No test set requested, return train and validation sets
-        if self.test_size == 0:
-            return (
-                X_train,
-                X_val,
-                None,
-                y_train,
-                y_val,
-                None,
-            )
-
-        # Return train, validation and test sets
+        # Return train, val and test sets
         return (
             X_train,
             X_val,

--- a/openadmet/models/split/sklearn.py
+++ b/openadmet/models/split/sklearn.py
@@ -14,31 +14,35 @@ class ShuffleSplitter(SplitterBase):
         Split the data
         """
 
-        # First split into train and val+test
-        X_train, X_val_test, y_train, y_val_test = train_test_split(
+        # No test nor validation set requested, return the entire dataset as train
+        if self.test_size == 0 and self.val_size == 0:
+            return X, None, None, y, None, None
+
+        # Split into train+val and test
+        X_train_val, X_test, y_train_val, y_test = train_test_split(
             X,
             y,
             train_size=None,
-            test_size=int((self.test_size + self.val_size) * X.shape[0]),
+            test_size=int(self.test_size * X.shape[0]),
             random_state=self.random_state,
         )
 
-        # If no validation set is requested, return train and test sets
+        # No validation set requested, return train and test sets
         if self.val_size == 0:
-            return X_train, None, X_val_test, y_train, None, y_val_test
+            return X_train_val, None, X_test, y_train_val, None, y_test
 
-        # If no test set is requested, return train and validation sets
-        elif self.test_size == 0:
-            return X_train, X_val_test, None, y_train, y_val_test, None
+        # Split train+val into train and validation sets
+        X_train, X_val, y_train, y_val = train_test_split(
+            X_train_val,
+            y_train_val,
+            train_size=None,
+            test_size=int(self.val_size * X.shape[0]),
+            random_state=self.random_state,
+        )
 
-        # If both test and validation sets are requested, split the remaining data
-        else:
-            X_val, X_test, y_val, y_test = train_test_split(
-                X_val_test,
-                y_val_test,
-                train_size=None,
-                test_size=int(self.test_size * X.shape[0]),
-                random_state=self.random_state,
-            )
+        # No test set requested, return train and validation sets
+        if self.test_size == 0:
+            return X_train, X_val, None, y_train, y_val, None
 
-            return X_train, X_val, X_test, y_train, y_val, y_test
+        # Return train, validation and test sets
+        return X_train, X_val, X_test, y_train, y_val, y_test

--- a/openadmet/models/split/sklearn.py
+++ b/openadmet/models/split/sklearn.py
@@ -14,9 +14,17 @@ class ShuffleSplitter(SplitterBase):
         Split the data
         """
 
-        # No test nor validation set requested, return the entire dataset as train
-        if self.test_size == 0 and self.val_size == 0:
-            return X, None, None, y, None, None
+        # No test set requested
+        if self.test_size == 0:
+            # Split into train and val
+            X_train, X_val, y_train, y_val = train_test_split(
+                X,
+                y,
+                train_size=None,
+                test_size=int(self.val_size * X.shape[0]),
+                random_state=self.random_state,
+            )
+            return X_train, X_val, None, y_train, y_val, None
 
         # Split into train+val and test
         X_train_val, X_test, y_train_val, y_test = train_test_split(
@@ -27,11 +35,11 @@ class ShuffleSplitter(SplitterBase):
             random_state=self.random_state,
         )
 
-        # No validation set requested, return train and test sets
+        # No validation set requested, return train(+val) and test sets
         if self.val_size == 0:
             return X_train_val, None, X_test, y_train_val, None, y_test
 
-        # Split train+val into train and validation sets
+        # Split train+val into train and val sets
         X_train, X_val, y_train, y_val = train_test_split(
             X_train_val,
             y_train_val,
@@ -40,9 +48,5 @@ class ShuffleSplitter(SplitterBase):
             random_state=self.random_state,
         )
 
-        # No test set requested, return train and validation sets
-        if self.test_size == 0:
-            return X_train, X_val, None, y_train, y_val, None
-
-        # Return train, validation and test sets
+        # Return train, val and test sets
         return X_train, X_val, X_test, y_train, y_val, y_test


### PR DESCRIPTION
## Description
Previously, splits were performed as train/val+test, then train/val/test. This results in inconsistent training sets when comparing models that use versus don't use a validation split (e.g. ChemProp versus LGBM). This PR ensures test splits are canonical.

Additionally, modifies structured splitters to split on structure for train+val/test, but simple random sampling to further split train and val.

Resolves #225
Resolves #172

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Change train+val/test to train/val+test
  - [X] Update return logic for edge cases (all train, no val, no test)
  - [X] Modify structured splitters to split train/val+test eponymously; shuffle split for train/val/test.

## Status
- [X] Ready to go
