### PR TITLE
Made taskname default so it will error correctly

### DIFF
--- a/openadmet/models/cli/compare.py
+++ b/openadmet/models/cli/compare.py
@@ -19,6 +19,7 @@ from openadmet.models.comparison.posthoc import PostHocComparison
 @click.option(
     "--taskname",
     help="Task names as they appear in the model stats JSON",
+    default="task_0",
     multiple=True,
 )
 @click.option(


### PR DESCRIPTION
Very quick fix, added a default to the taskname argument, going to also call it task-name to make it consistent naming with our other cli arguments
