### PR TITLE
Fixes task-name vs taskname bug in posthoc cli

### DIFF
--- a/openadmet/models/cli/compare.py
+++ b/openadmet/models/cli/compare.py
@@ -35,7 +35,7 @@ from openadmet.models.comparison.posthoc import PostHocComparison
     type=bool,
 )
 def compare(
-    model_stats, model_tag, task_name, output_dir=None, report=False, 
+    model_stats, model_tag, task_name, output_dir=None, report=False,
 ):
     """Compare two or more models from summary statistics"""
     comp = PostHocComparison()

--- a/openadmet/models/cli/compare.py
+++ b/openadmet/models/cli/compare.py
@@ -35,11 +35,11 @@ from openadmet.models.comparison.posthoc import PostHocComparison
     type=bool,
 )
 def compare(
-    model_stats, model_tag, taskname, report=False, output_dir=None,
+    model_stats, model_tag, task_name, output_dir=None, report=False, 
 ):
     """Compare two or more models from summary statistics"""
     comp = PostHocComparison()
-    comp.compare(model_stats, model_tag, task_tags=taskname,
+    comp.compare(model_stats, model_tag, task_name,
                  output_dir=output_dir, report=report)
 
 


### PR DESCRIPTION
CLI had an issue with argument names (task_name not changed from taskname in compare()), names not fully changed before last merge, just a quick fix