### PR TITLE
Add uncertainty calibration to evaluation pipeline

### DIFF
--- a/openadmet/models/active_learning/committee.py
+++ b/openadmet/models/active_learning/committee.py
@@ -224,7 +224,9 @@ class CommitteeRegressor(EnsembleBase):
         for i in range(y.shape[-1]):
             plots.append(
                 uct.viz.plot_calibration(
-                    y_pred_mean.flatten(), y_pred_std.flatten(), y[:, i].flatten()
+                    y_pred_mean[:, i].flatten(),
+                    y_pred_std[:, i].flatten(),
+                    y[:, i].flatten(),
                 )
             )
 

--- a/openadmet/models/active_learning/committee.py
+++ b/openadmet/models/active_learning/committee.py
@@ -167,7 +167,7 @@ class CommitteeRegressor(EnsembleBase):
         if method not in self._calibration_methods:
             raise ValueError(
                 f"Invalid calibration method: {method}. "
-                f"Valid options are: {self._calibration_methods.keys()}"
+                f"Valid options are: {self._calibration_methods.keys()}."
             )
 
         getattr(self, self._calibration_methods[method])(X, y, **kwargs)

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -257,8 +257,18 @@ class EnsembleSpec(AnvilSection):
 
     section_name: ClassVar[str] = "ensemble"
     n_models: int
+    calibration_method: str = "isotonic-regression"
     param_paths: list[str] | None = None
     serial_paths: list[str] | None = None
+
+    @field_validator("method")
+    def check_method(cls, value):
+        allowed = ["isotonic-regression", "scaling-factor"]
+        if value not in allowed:
+            raise ValueError(
+                f"Invalid calibration method: {value}. Valid options are: {allowed}."
+            )
+        return value
 
     @field_validator("n_models")
     def check_n_models(cls, value):

--- a/openadmet/models/anvil/specification.py
+++ b/openadmet/models/anvil/specification.py
@@ -261,7 +261,7 @@ class EnsembleSpec(AnvilSection):
     param_paths: list[str] | None = None
     serial_paths: list[str] | None = None
 
-    @field_validator("method")
+    @field_validator("calibration_method")
     def check_method(cls, value):
         allowed = ["isotonic-regression", "scaling-factor"]
         if value not in allowed:

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -303,6 +303,7 @@ class AnvilWorkflow(AnvilWorkflowBase):
         # Check if the model has predict_proba method (classification)
         if hasattr(self.model, "predict_proba"):
             y_pred = self.model.predict_proba(X_test_feat)
+            y_std = None
 
         # Otherwise, regression
         else:

--- a/openadmet/models/anvil/workflow.py
+++ b/openadmet/models/anvil/workflow.py
@@ -263,7 +263,11 @@ class AnvilWorkflow(AnvilWorkflowBase):
             self._train_ensemble(X_train_feat, y_train, output_dir)
 
             # Calibrate
-            self.model.calibrate_uncertainty(X_val_feat, y_val)
+            self.model.calibrate_uncertainty(
+                X_val_feat,
+                y_val,
+                method=self.parent_spec.procedure.ensemble.calibration_method,
+            )
 
             # Save
             logger.info("Saving model")
@@ -302,7 +306,11 @@ class AnvilWorkflow(AnvilWorkflowBase):
 
         # Otherwise, regression
         else:
-            y_pred = self.model.predict(X_test_feat)
+            if self.ensemble:
+                y_pred, y_std = self.model.predict(X_test_feat, return_std=True)
+            else:
+                y_pred = self.model.predict(X_test_feat)
+                y_std = None
         logger.info("Predictions made")
 
         # Run evaluation on train/test
@@ -312,6 +320,7 @@ class AnvilWorkflow(AnvilWorkflowBase):
             eval.evaluate(
                 y_true=y_test,
                 y_pred=y_pred,
+                y_std=y_std,
                 model=self.model,
                 X_train=X_train_feat,
                 y_train=y_train,
@@ -595,6 +604,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             self.model.calibrate_uncertainty(
                 val_dataloader,
                 y_val,
+                method=self.parent_spec.procedure.ensemble.calibration_method,
                 accelerator=self.trainer.accelerator,
                 devices=self.trainer.devices,
             )
@@ -630,11 +640,20 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
 
         # Predict on test set
         logger.info("Predicting")
-        y_pred = self.model.predict(
-            test_dataloader,
-            accelerator=self.trainer.accelerator,
-            devices=self.trainer.devices,
-        )
+        if self.ensemble:
+            y_pred, y_std = self.model.predict(
+                test_dataloader,
+                accelerator=self.trainer.accelerator,
+                devices=self.trainer.devices,
+                return_std=True,
+            )
+        else:
+            y_pred = self.model.predict(
+                test_dataloader,
+                accelerator=self.trainer.accelerator,
+                devices=self.trainer.devices,
+            )
+            y_std = None
         logger.info("Predictions made")
 
         # Run evaluation on train/test
@@ -649,6 +668,7 @@ class AnvilDeepLearningWorkflow(AnvilWorkflowBase):
             eval.evaluate(
                 y_true=y_test,
                 y_pred=y_pred,
+                y_std=y_std,
                 model=self.model,
                 X_train=train_dataloader,
                 y_train=train_dataloader,

--- a/openadmet/models/eval/eval_base.py
+++ b/openadmet/models/eval/eval_base.py
@@ -26,6 +26,14 @@ def mask_nans(y_true: np.ndarray, y_pred: np.ndarray):
     return y_true[mask], y_pred[mask]
 
 
+def mask_nans_std(y_true: np.ndarray, y_pred: np.ndarray, y_std: np.ndarray):
+    """
+    Remove any pairs where either y_true or y_pred is NaN.
+    """
+    mask = ~np.isnan(y_true) & ~np.isnan(y_pred)
+    return y_true[mask], y_pred[mask], y_std[mask]
+
+
 class EvalBase(BaseModel):
     class Config:
         extra = "allow"

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -1,0 +1,80 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import uncertainty_toolbox as uct
+from pydantic import Field
+
+from openadmet.models.eval.eval_base import EvalBase, evaluators
+
+
+@evaluators.register("UncertaintyPlots")
+class UncertaintyPlots(EvalBase):
+    use_wandb: bool = Field(False, description="Whether to use wandb")
+    dpi: int = Field(300, description="DPI for the plot")
+    _plots = {}
+    _plot_data = {}
+
+    def evaluate(self, y_true, y_pred, y_std, target_labels=None):
+        # Check inputs
+        if y_true is None or y_pred is None or y_std is None:
+            raise ValueError("Must provide `y_true`, `y_pred`, and `y_std`")
+
+        # Convert to numpy array if needed
+        if isinstance(y_true, (pd.Series, pd.DataFrame)):
+            y_true = y_true.to_numpy()
+
+        # Ensure 2D arrays for consistency
+        if y_pred.ndim == 1:
+            y_pred = y_pred.reshape(-1, 1)
+        if y_true.ndim == 1:
+            y_true = y_true.reshape(-1, 1)
+        if y_std.ndim == 1:
+            y_std = y_std.reshape(-1, 1)
+
+        # Verify number of tasks
+        n_tasks = y_true.shape[1]
+        if (n_tasks != y_pred.shape[1]) or (n_tasks != y_std.shape[1]):
+            raise ValueError(
+                "`y_true`, `y_pred`, and `y_std` must have the same number of tasks"
+            )
+
+        # Construct target labels if not provided
+        if target_labels is None:
+            target_labels = [f"task_{i}" for i in range(n_tasks)]
+
+        # Specify plots
+        self._plots = {
+            "calibration": self.plot_calibration,
+        }
+
+        # Enumerate targets
+        for task_id, task_label in enumerate(target_labels):
+            # Enumerate plots
+            for plot_tag, plot in self._plots.items():
+                self.plot_data[f"{task_label}_{plot_tag}"] = plot(
+                    y_true[:, task_id],
+                    y_pred[:, task_id],
+                    y_std[:, task_id],
+                    title=f"Uncertainty Calibration\nTask {task_label}",
+                    dpi=self.dpi,
+                )
+
+        return self._plot_data
+
+    @staticmethod
+    def plot_calibration(y_true, y_pred, y_std, title="", dpi=300):
+        # Plot calibration
+        fig, ax = plt.subplots(dpi=dpi)
+        ax = uct.viz.plot_calibration(
+            y_pred,
+            y_std,
+            y_true,
+            ax=ax,
+        )
+
+        # Set title
+        ax.set_title(title)
+
+        return fig
+
+    def report(self):
+        pass

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -1,17 +1,186 @@
+import json
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import uncertainty_toolbox as uct
+import wandb
 from pydantic import Field
 
 from openadmet.models.eval.eval_base import EvalBase, evaluators
 
 
-@evaluators.register("UncertaintyPlots")
+@evaluators.register("UncertaintyMetrics")
+class UncertaintyMetrics(EvalBase):
+    use_wandb: bool = Field(False, description="Whether to use wandb")
+    _data: dict = {}
+
+    _metrics: dict = {
+        "mae": "MAE",
+        "rmse": "RMSE",
+        "mdae": "MDAE",
+        "marpd": "MARPD",
+        "r2": "$R^2$",
+        "corr": "Correlation",
+        "rms_cal": "Root-mean-squared Calibration Error",
+        "ma_cal": "Mean-absolute Calibration Error",
+        "miscal_area": "Miscalibration Area",
+        "sharp": "Sharpness",
+        "nll": "Negative-log-likelihood",
+        "crps": "CRPS",
+        "check": "Check Score",
+        "interval": "Interval Score",
+        "rms_adv_group_cal": "Root-mean-squared Adversarial Group Calibration Error",
+        "ma_adv_group_cal": "Mean-absolute Adversarial Group Calibration Error",
+    }
+
+    @property
+    def metric_names(self):
+        """
+        Return the metric names
+        """
+        return list(self._metrics.keys())
+
+    @property
+    def task_names(self):
+        """
+        Return the task names
+        """
+        return list(self._data.keys())
+
+    def evaluate(
+        self,
+        y_true,
+        y_pred,
+        y_std,
+        target_labels=None,
+        bins=100,
+        resolution=99,
+        scaled=True,
+    ):
+        # Check inputs
+        if y_true is None or y_pred is None or y_std is None:
+            raise ValueError("Must provide `y_true`, `y_pred`, and `y_std`")
+
+        # Convert to numpy array if needed
+        if isinstance(y_true, (pd.Series, pd.DataFrame)):
+            y_true = y_true.to_numpy()
+
+        # Ensure 2D arrays for consistency
+        if y_pred.ndim == 1:
+            y_pred = y_pred.reshape(-1, 1)
+        if y_true.ndim == 1:
+            y_true = y_true.reshape(-1, 1)
+        if y_std.ndim == 1:
+            y_std = y_std.reshape(-1, 1)
+
+        # Verify number of tasks
+        n_tasks = y_true.shape[1]
+        if (n_tasks != y_pred.shape[1]) or (n_tasks != y_std.shape[1]):
+            raise ValueError(
+                "`y_true`, `y_pred`, and `y_std` must have the same number of tasks"
+            )
+
+        # Construct target labels if not provided
+        if target_labels is None:
+            target_labels = [f"task_{i}" for i in range(n_tasks)]
+
+        # Enumerate targets
+        for task_id, task_label in enumerate(target_labels):
+            # Initialize task data
+            self._data[task_label] = {}
+
+            # Accuracy
+            accuracy_metrics = uct.metrics.get_all_accuracy_metrics(
+                y_pred[task_id, :].flatten(), y_true[task_id, :].flatten(), False
+            )
+
+            # Calibration
+            calibration_metrics = uct.metrics.get_all_average_calibration(
+                y_pred[task_id, :].flatten(),
+                y_std[task_id, :].flatten(),
+                y_true[task_id, :].flatten(),
+                bins,
+                False,
+            )
+
+            # # Adversarial Group Calibration
+            # adv_group_cali_metrics = uct.metrics.get_all_adversarial_group_calibration(
+            #     y_pred[task_id, :].flatten(),
+            #     y_std[task_id, :].flatten(),
+            #     y_true[task_id, :].flatten(),
+            #     bins,
+            #     False,
+            # )
+
+            # Sharpness
+            sharpness_metrics = uct.metrics.get_all_sharpness_metrics(
+                y_std[task_id, :].flatten(), False
+            )
+
+            # Proper Scoring Rules
+            scoring_rule_metrics = uct.metrics.get_all_scoring_rule_metrics(
+                y_pred[task_id, :].flatten(),
+                y_std[task_id, :].flatten(),
+                y_true[task_id, :].flatten(),
+                resolution,
+                scaled,
+                False,
+            )
+
+            # Store metrics
+            for metric_dict in [
+                accuracy_metrics,
+                calibration_metrics,
+                sharpness_metrics,
+                scoring_rule_metrics,
+                # adv_group_cali_metrics,
+            ]:
+                self._data[task_label].update(metric_dict)
+
+    def report(self, write=False, output_dir=None):
+        """
+        Report the evaluation
+        """
+        if write:
+            self.write_report(output_dir)
+
+        return self._data
+
+    def write_report(self, output_dir):
+        """
+        Write the evaluation report
+        """
+        # Write to JSON
+        json_path = output_dir / "uncertainty_calibration_metrics.json"
+        with open(json_path, "w") as f:
+            json.dump(self._data, f, indent=2)
+
+        # Also log the JSON to wandb
+        if self.use_wandb:
+            artifact = wandb.Artifact(
+                name="uncertainty_calibration_json", type="metric_json"
+            )
+            # Add a file to the artifact
+            artifact.add_file(json_path)
+            # Log the artifact
+            wandb.log_artifact(artifact)
+
+
+@evaluators.register("UncertaintyCalibrationPlots")
 class UncertaintyPlots(EvalBase):
     use_wandb: bool = Field(False, description="Whether to use wandb")
     dpi: int = Field(300, description="DPI for the plot")
-    _plots = {}
-    _plot_data = {}
+    _plots: dict = {}
+    _plot_data: dict = {}
+
+    def model_post_init(self, __context) -> None:
+        self._set_plot_types()
+
+    def _set_plot_types(self):
+        # Specify plots
+        self._plots = {
+            "calibration": self.calibration_plot,
+        }
 
     def evaluate(self, y_true, y_pred, y_std, target_labels=None):
         # Check inputs
@@ -41,11 +210,6 @@ class UncertaintyPlots(EvalBase):
         if target_labels is None:
             target_labels = [f"task_{i}" for i in range(n_tasks)]
 
-        # Specify plots
-        self._plots = {
-            "calibration": self.plot_calibration,
-        }
-
         # Enumerate targets
         for task_id, task_label in enumerate(target_labels):
             # Enumerate plots
@@ -61,20 +225,41 @@ class UncertaintyPlots(EvalBase):
         return self._plot_data
 
     @staticmethod
-    def plot_calibration(y_true, y_pred, y_std, title="", dpi=300):
+    def calibration_plot(y_true, y_pred, y_std, title="", dpi=300):
         # Plot calibration
         fig, ax = plt.subplots(dpi=dpi)
         ax = uct.viz.plot_calibration(
-            y_pred,
-            y_std,
-            y_true,
+            y_pred.flatten(),
+            y_std.flatten(),
+            y_true.flatten(),
             ax=ax,
         )
+
+        # Change dashed line color
+        ax.get_lines()[0].set_color("black")
 
         # Set title
         ax.set_title(title)
 
         return fig
 
-    def report(self):
-        pass
+    def report(self, write=False, output_dir=None):
+        """
+        Report the evaluation
+        """
+
+        if write:
+            self.write_report(output_dir)
+
+        return self._plot_data
+
+    def write_report(self, output_dir):
+        """
+        Write the evaluation report
+        """
+
+        for plot_tag, plot in self._plot_data.items():
+            plot_path = output_dir / f"{plot_tag}.png"
+            plot.savefig(plot_path, dpi=self.dpi)
+            if self.use_wandb:
+                wandb.log({plot_tag: wandb.Image(str(plot_path))})

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -11,6 +11,19 @@ from openadmet.models.eval.eval_base import EvalBase, evaluators, mask_nans_std
 
 @evaluators.register("UncertaintyMetrics")
 class UncertaintyMetrics(EvalBase):
+    """
+    Evaluator for uncertainty metrics using uncertainty_toolbox.
+
+    Attributes
+    ----------
+    use_wandb : bool
+        Whether to use wandb for logging.
+    _data : dict
+        Stores computed metrics for each task.
+    _metrics : dict
+        Mapping of metric keys to human-readable names.
+    """
+
     use_wandb: bool = Field(False, description="Whether to use wandb")
     _data: dict = {}
     _metrics: dict = {
@@ -35,14 +48,24 @@ class UncertaintyMetrics(EvalBase):
     @property
     def metric_names(self):
         """
-        Return the metric names
+        Get the list of metric keys.
+
+        Returns
+        -------
+        list of str
+            List of metric keys.
         """
         return list(self._metrics.keys())
 
     @property
     def task_names(self):
         """
-        Return the task names
+        Get the list of evaluated task names.
+
+        Returns
+        -------
+        list of str
+            List of task names.
         """
         return list(self._data.keys())
 
@@ -57,6 +80,33 @@ class UncertaintyMetrics(EvalBase):
         scaled=True,
         **kwargs,
     ):
+        """
+        Evaluate uncertainty metrics for each task.
+
+        Parameters
+        ----------
+        y_true : array-like
+            Ground truth values.
+        y_pred : array-like
+            Predicted mean values.
+        y_std : array-like
+            Predicted standard deviations.
+        target_labels : list of str, optional
+            List of target labels for each task.
+        bins : int, default=100
+            Number of bins for calibration metrics.
+        resolution : int, default=99
+            Resolution for scoring rule metrics.
+        scaled : bool, default=True
+            Whether to scale scoring rule metrics.
+        **kwargs
+            Additional keyword arguments.
+
+        Raises
+        ------
+        ValueError
+            If required inputs are missing or shapes are inconsistent.
+        """
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
             raise ValueError("Must provide `y_true`, `y_pred`, and `y_std`")
@@ -141,7 +191,19 @@ class UncertaintyMetrics(EvalBase):
 
     def report(self, write=False, output_dir=None):
         """
-        Report the evaluation
+        Report the evaluation results.
+
+        Parameters
+        ----------
+        write : bool, default=False
+            Whether to write the report to disk.
+        output_dir : Path or str, optional
+            Directory to write the report to.
+
+        Returns
+        -------
+        dict
+            Dictionary of computed metrics.
         """
         if write:
             self.write_report(output_dir)
@@ -150,7 +212,12 @@ class UncertaintyMetrics(EvalBase):
 
     def write_report(self, output_dir):
         """
-        Write the evaluation report
+        Write the evaluation report to disk and optionally log to wandb.
+
+        Parameters
+        ----------
+        output_dir : Path or str
+            Directory to write the report to.
         """
         # Write to JSON
         json_path = output_dir / "uncertainty_calibration_metrics.json"
@@ -170,21 +237,73 @@ class UncertaintyMetrics(EvalBase):
 
 @evaluators.register("UncertaintyPlots")
 class UncertaintyPlots(EvalBase):
+    """
+    Evaluator for generating uncertainty plots.
+
+    Attributes
+    ----------
+    use_wandb : bool
+        Whether to use wandb for logging.
+    dpi : int
+        DPI for the generated plots.
+    _plots : dict
+        Mapping of plot tags to plotting functions.
+    _plot_data : dict
+        Stores generated plot figures.
+    """
+
     use_wandb: bool = Field(False, description="Whether to use wandb")
     dpi: int = Field(300, description="DPI for the plot")
     _plots: dict = {}
     _plot_data: dict = {}
 
     def model_post_init(self, __context):
+        """
+        Post-initialization hook to set plot types.
+
+        Parameters
+        ----------
+        __context : Any
+            Pydantic context (unused).
+        """
         self._set_plot_types()
 
     def _set_plot_types(self):
+        """
+        Set the available plot types.
+        """
         # Specify plots
         self._plots = {
             "uncertainty-calibration-plot": self.calibration_plot,
         }
 
     def evaluate(self, y_true, y_pred, y_std, target_labels=None, **kwargs):
+        """
+        Generate uncertainty plots for each task.
+
+        Parameters
+        ----------
+        y_true : array-like
+            Ground truth values.
+        y_pred : array-like
+            Predicted mean values.
+        y_std : array-like
+            Predicted standard deviations.
+        target_labels : list of str, optional
+            List of target labels for each task.
+        **kwargs
+            Additional keyword arguments.
+
+        Returns
+        -------
+        dict
+            Dictionary of generated plot figures.
+        
+        Raises
+        ------
+        ValueError
+            If required inputs are missing or shapes are inconsistent.
+        """
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
             raise ValueError("Must provide `y_true`, `y_pred`, and `y_std`")
@@ -237,7 +356,25 @@ class UncertaintyPlots(EvalBase):
     @staticmethod
     def calibration_plot(y_true, y_pred, y_std, title="", dpi=300):
         """
-        Create a calibration plot.
+        Create a calibration plot for uncertainty estimates.
+
+        Parameters
+        ----------
+        y_true : array-like
+            Ground truth values.
+        y_pred : array-like
+            Predicted mean values.
+        y_std : array-like
+            Predicted standard deviations.
+        title : str, default=""
+            Title for the plot.
+        dpi : int, default=300
+            DPI for the plot.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+            The generated calibration plot figure.
         """
         # Plot calibration
         fig, ax = plt.subplots(dpi=dpi)
@@ -258,7 +395,19 @@ class UncertaintyPlots(EvalBase):
 
     def report(self, write=False, output_dir=None):
         """
-        Report the evaluation
+        Report the generated plots.
+
+        Parameters
+        ----------
+        write : bool, default=False
+            Whether to write the plots to disk.
+        output_dir : Path or str, optional
+            Directory to write the plots to.
+
+        Returns
+        -------
+        dict
+            Dictionary of generated plot figures.
         """
 
         if write:
@@ -268,7 +417,12 @@ class UncertaintyPlots(EvalBase):
 
     def write_report(self, output_dir):
         """
-        Write the evaluation report
+        Write the generated plots to disk and optionally log to wandb.
+
+        Parameters
+        ----------
+        output_dir : Path or str
+            Directory to write the plots to.
         """
 
         for plot_tag, plot in self._plot_data.items():

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -22,6 +22,7 @@ class UncertaintyMetrics(EvalBase):
         Stores computed metrics for each task.
     _metrics : dict
         Mapping of metric keys to human-readable names.
+
     """
 
     use_wandb: bool = Field(False, description="Whether to use wandb")
@@ -54,6 +55,7 @@ class UncertaintyMetrics(EvalBase):
         -------
         list of str
             List of metric keys.
+
         """
         return list(self._metrics.keys())
 
@@ -66,6 +68,7 @@ class UncertaintyMetrics(EvalBase):
         -------
         list of str
             List of task names.
+
         """
         return list(self._data.keys())
 
@@ -106,6 +109,7 @@ class UncertaintyMetrics(EvalBase):
         ------
         ValueError
             If required inputs are missing or shapes are inconsistent.
+
         """
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
@@ -204,6 +208,7 @@ class UncertaintyMetrics(EvalBase):
         -------
         dict
             Dictionary of computed metrics.
+
         """
         if write:
             self.write_report(output_dir)
@@ -218,6 +223,7 @@ class UncertaintyMetrics(EvalBase):
         ----------
         output_dir : Path or str
             Directory to write the report to.
+
         """
         # Write to JSON
         json_path = output_dir / "uncertainty_calibration_metrics.json"
@@ -250,6 +256,7 @@ class UncertaintyPlots(EvalBase):
         Mapping of plot tags to plotting functions.
     _plot_data : dict
         Stores generated plot figures.
+
     """
 
     use_wandb: bool = Field(False, description="Whether to use wandb")
@@ -265,6 +272,7 @@ class UncertaintyPlots(EvalBase):
         ----------
         __context : Any
             Pydantic context (unused).
+
         """
         self._set_plot_types()
 
@@ -298,11 +306,12 @@ class UncertaintyPlots(EvalBase):
         -------
         dict
             Dictionary of generated plot figures.
-        
+
         Raises
         ------
         ValueError
             If required inputs are missing or shapes are inconsistent.
+
         """
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
@@ -375,6 +384,7 @@ class UncertaintyPlots(EvalBase):
         -------
         matplotlib.figure.Figure
             The generated calibration plot figure.
+
         """
         # Plot calibration
         fig, ax = plt.subplots(dpi=dpi)
@@ -408,8 +418,8 @@ class UncertaintyPlots(EvalBase):
         -------
         dict
             Dictionary of generated plot figures.
-        """
 
+        """
         if write:
             self.write_report(output_dir)
 
@@ -423,8 +433,8 @@ class UncertaintyPlots(EvalBase):
         ----------
         output_dir : Path or str
             Directory to write the plots to.
-        """
 
+        """
         for plot_tag, plot in self._plot_data.items():
             plot_path = output_dir / f"{plot_tag}.png"
             plot.savefig(plot_path, dpi=self.dpi)

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -56,6 +56,7 @@ class UncertaintyMetrics(EvalBase):
         bins=100,
         resolution=99,
         scaled=True,
+        **kwargs,
     ):
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
@@ -166,7 +167,7 @@ class UncertaintyMetrics(EvalBase):
             wandb.log_artifact(artifact)
 
 
-@evaluators.register("UncertaintyCalibrationPlots")
+@evaluators.register("UncertaintyPlots")
 class UncertaintyPlots(EvalBase):
     use_wandb: bool = Field(False, description="Whether to use wandb")
     dpi: int = Field(300, description="DPI for the plot")
@@ -179,10 +180,10 @@ class UncertaintyPlots(EvalBase):
     def _set_plot_types(self):
         # Specify plots
         self._plots = {
-            "calibration": self.calibration_plot,
+            "uncertainty-calibration-plot": self.calibration_plot,
         }
 
-    def evaluate(self, y_true, y_pred, y_std, target_labels=None):
+    def evaluate(self, y_true, y_pred, y_std, target_labels=None, **kwargs):
         # Check inputs
         if y_true is None or y_pred is None or y_std is None:
             raise ValueError("Must provide `y_true`, `y_pred`, and `y_std`")
@@ -214,7 +215,7 @@ class UncertaintyPlots(EvalBase):
         for task_id, task_label in enumerate(target_labels):
             # Enumerate plots
             for plot_tag, plot in self._plots.items():
-                self.plot_data[f"{task_label}_{plot_tag}"] = plot(
+                self._plot_data[f"{task_label}_{plot_tag}"] = plot(
                     y_true[:, task_id],
                     y_pred[:, task_id],
                     y_std[:, task_id],
@@ -226,6 +227,9 @@ class UncertaintyPlots(EvalBase):
 
     @staticmethod
     def calibration_plot(y_true, y_pred, y_std, title="", dpi=300):
+        """
+        Create a calibration plot.
+        """
         # Plot calibration
         fig, ax = plt.subplots(dpi=dpi)
         ax = uct.viz.plot_calibration(

--- a/openadmet/models/eval/uncertainty.py
+++ b/openadmet/models/eval/uncertainty.py
@@ -6,14 +6,13 @@ import uncertainty_toolbox as uct
 import wandb
 from pydantic import Field
 
-from openadmet.models.eval.eval_base import EvalBase, evaluators
+from openadmet.models.eval.eval_base import EvalBase, evaluators, mask_nans_std
 
 
 @evaluators.register("UncertaintyMetrics")
 class UncertaintyMetrics(EvalBase):
     use_wandb: bool = Field(False, description="Whether to use wandb")
     _data: dict = {}
-
     _metrics: dict = {
         "mae": "MAE",
         "rmse": "RMSE",
@@ -87,42 +86,44 @@ class UncertaintyMetrics(EvalBase):
 
         # Enumerate targets
         for task_id, task_label in enumerate(target_labels):
+            # Task target values
+            t_true = y_true[:, task_id].flatten()
+            t_pred = y_pred[:, task_id].flatten()
+            t_std = y_std[:, task_id].flatten()
+
+            # Mask nans
+            t_true, t_pred, t_std = mask_nans_std(t_true, t_pred, t_std)
+
             # Initialize task data
             self._data[task_label] = {}
 
             # Accuracy
             accuracy_metrics = uct.metrics.get_all_accuracy_metrics(
-                y_pred[task_id, :].flatten(), y_true[task_id, :].flatten(), False
+                t_pred, t_true, False
             )
 
             # Calibration
             calibration_metrics = uct.metrics.get_all_average_calibration(
-                y_pred[task_id, :].flatten(),
-                y_std[task_id, :].flatten(),
-                y_true[task_id, :].flatten(),
-                bins,
-                False,
+                t_pred, t_std, t_true, bins, False
             )
 
             # # Adversarial Group Calibration
             # adv_group_cali_metrics = uct.metrics.get_all_adversarial_group_calibration(
-            #     y_pred[task_id, :].flatten(),
-            #     y_std[task_id, :].flatten(),
-            #     y_true[task_id, :].flatten(),
+            #     t_pred,
+            #     t_std,
+            #     t_true,
             #     bins,
             #     False,
             # )
 
             # Sharpness
-            sharpness_metrics = uct.metrics.get_all_sharpness_metrics(
-                y_std[task_id, :].flatten(), False
-            )
+            sharpness_metrics = uct.metrics.get_all_sharpness_metrics(t_std, False)
 
             # Proper Scoring Rules
             scoring_rule_metrics = uct.metrics.get_all_scoring_rule_metrics(
-                y_pred[task_id, :].flatten(),
-                y_std[task_id, :].flatten(),
-                y_true[task_id, :].flatten(),
+                t_pred,
+                t_std,
+                t_true,
                 resolution,
                 scaled,
                 False,
@@ -174,7 +175,7 @@ class UncertaintyPlots(EvalBase):
     _plots: dict = {}
     _plot_data: dict = {}
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, __context):
         self._set_plot_types()
 
     def _set_plot_types(self):
@@ -213,12 +214,20 @@ class UncertaintyPlots(EvalBase):
 
         # Enumerate targets
         for task_id, task_label in enumerate(target_labels):
+            # Task target values
+            t_true = y_true[:, task_id].flatten()
+            t_pred = y_pred[:, task_id].flatten()
+            t_std = y_std[:, task_id].flatten()
+
+            # Mask nans
+            t_true, t_pred, t_std = mask_nans_std(t_true, t_pred, t_std)
+
             # Enumerate plots
             for plot_tag, plot in self._plots.items():
                 self._plot_data[f"{task_label}_{plot_tag}"] = plot(
-                    y_true[:, task_id],
-                    y_pred[:, task_id],
-                    y_std[:, task_id],
+                    t_true,
+                    t_pred,
+                    t_std,
                     title=f"Uncertainty Calibration\nTask {task_label}",
                     dpi=self.dpi,
                 )
@@ -233,9 +242,9 @@ class UncertaintyPlots(EvalBase):
         # Plot calibration
         fig, ax = plt.subplots(dpi=dpi)
         ax = uct.viz.plot_calibration(
-            y_pred.flatten(),
-            y_std.flatten(),
-            y_true.flatten(),
+            y_pred,
+            y_std,
+            y_true,
             ax=ax,
         )
 

--- a/openadmet/models/registries.py
+++ b/openadmet/models/registries.py
@@ -2,53 +2,52 @@
 # before importing the registry classes
 # there must be a better way to do this, but for now this works
 
-from openadmet.models.active_learning.committee import *  # noqa: F401 F403
-
 # active learning
+from openadmet.models.active_learning.committee import *  # noqa: F401 F403
 from openadmet.models.active_learning.ensemble_base import ensemblers  # noqa: F401 F403
+
+# models
 from openadmet.models.architecture.catboost import *  # noqa: F401 F403
 from openadmet.models.architecture.chemprop import *  # noqa: F401 F403  # noqa: F401 F403
 from openadmet.models.architecture.gat import *  # noqa: F401 F403
-
-# eval
-# models
 from openadmet.models.architecture.dummy import *  # noqa: F401 F403
 from openadmet.models.architecture.lgbm import *  # noqa: F401 F403  # noqa: F401 F403
-from openadmet.models.architecture.model_base import models  # noqa: F401  F403
 from openadmet.models.architecture.mtenn import *  # noqa: F401 F403
 from openadmet.models.architecture.rf import *  # noqa: F401 F403
 from openadmet.models.architecture.svm import *  # noqa: F401 F403
 from openadmet.models.architecture.tabpfn import *  # noqa: F401 F403
 from openadmet.models.architecture.xgboost import *  # noqa: F401 F403
-from openadmet.models.eval.classification import *  # noqa: F401 F403
-from openadmet.models.eval.cross_validation import *  # noqa: F401 F403
-from openadmet.models.eval.eval_base import evaluators  # noqa: F401 F403
+from openadmet.models.architecture.model_base import models  # noqa: F401  F403
 
 # evaluators
+from openadmet.models.eval.classification import *  # noqa: F401 F403
+from openadmet.models.eval.cross_validation import *  # noqa: F401 F403
 from openadmet.models.eval.regression import *  # noqa: F401 F403
-from openadmet.models.features.chemprop import *  # noqa: F401 F403
-from openadmet.models.features.combine import *  # noqa: F401 F403
-from openadmet.models.features.feature_base import featurizers  # noqa: F401 F403
-from openadmet.models.features.gat_featurizer import *  # noqa: F401 F403
+from openadmet.models.eval.uncertainty import *  # noqa: F401 F403
+from openadmet.models.eval.eval_base import evaluators  # noqa: F401 F403
 
 # featurizers
+from openadmet.models.features.chemprop import *  # noqa: F401 F403
+from openadmet.models.features.combine import *  # noqa: F401 F403
+from openadmet.models.features.gat_featurizer import *  # noqa: F401 F403
 from openadmet.models.features.molfeat_fingerprint import *  # noqa: F401 F403
 from openadmet.models.features.molfeat_properties import *  # noqa: F401 F403
 from openadmet.models.features.mtenn import *  # noqa: F401 F403
+from openadmet.models.features.feature_base import featurizers  # noqa: F401 F403
 
 # util
 from openadmet.models.log import logger  # noqa: F401 F403
-from openadmet.models.split.scaffold import *  # noqa: F401 F403
 
 # splitters
+from openadmet.models.split.scaffold import *  # noqa: F401 F403
 from openadmet.models.split.sklearn import *  # noqa: F401 F403
 from openadmet.models.split.split_base import splitters  # noqa: F401 F403
-from openadmet.models.trainer.lightning import *  # noqa: F401 F403
 
 # trainers
+from openadmet.models.trainer.lightning import *  # noqa: F401 F403
 from openadmet.models.trainer.sklearn import *  # noqa: F401 F403
 from openadmet.models.trainer.trainer_base import trainers  # noqa: F401 F403
-from openadmet.models.transforms.impute import *  # noqa: F401 F403
 
 # transforms
+from openadmet.models.transforms.impute import *  # noqa: F401 F403
 from openadmet.models.transforms.transform_base import *  # noqa: F401 F403

--- a/openadmet/models/tests/integration/test_data/chemeleon_MT_ensemble.yaml
+++ b/openadmet/models/tests/integration/test_data/chemeleon_MT_ensemble.yaml
@@ -73,7 +73,7 @@ report:
       min_val: 3
       pXC50: true
       title: Multitask True vs Predicted pChEMBL on test set
-    
+
   - type: UncertaintyMetrics
     params:
       bins: 100

--- a/openadmet/models/tests/integration/test_data/chemeleon_MT_ensemble.yaml
+++ b/openadmet/models/tests/integration/test_data/chemeleon_MT_ensemble.yaml
@@ -73,3 +73,12 @@ report:
       min_val: 3
       pXC50: true
       title: Multitask True vs Predicted pChEMBL on test set
+    
+  - type: UncertaintyMetrics
+    params:
+      bins: 100
+      resolution: 99
+      scaled: True
+
+  - type: UncertaintyPlots
+    params: {}

--- a/openadmet/models/tests/integration/test_data/lgbm_fp_ensemble.yaml
+++ b/openadmet/models/tests/integration/test_data/lgbm_fp_ensemble.yaml
@@ -93,3 +93,12 @@ report:
       n_splits: 3
       n_repeats: 2
       title:  True vs Predicted pChEMBL on test set
+  # Generate uncertainty metrics
+  - type: UncertaintyMetrics
+    params:
+      bins: 100
+      resolution: 99
+      scaled: True
+  # Generate uncertainty plots
+  - type: UncertaintyPlots
+    params: {}


### PR DESCRIPTION
## Description
If training an ensemble, we should be able to output calibration plots (before and after) as well as the appropriate metrics as an `Eval`

## Todos
  - [x] Expose uncertainty calibration method in `EnsembleSpec`
  - [x] Metrics
  - [x] Plots
  - [x] Tests
  - [x] Docstrings

## Status
- [x] Ready to go
