### PR TITLE
Simplify PR template by removing unnecessary sections and add DCO

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,9 @@
 ## Description
 Provide a brief description of the PR's purpose here.
 
-## Todos
-Notable points that this PR has either accomplished or will accomplish.
-  - [ ] TODO 1
-
-## Questions
-- [ ] Question1
-
 ## Status
 - [ ] Ready to go
+
+
+## Developers certificate of origin
+- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


### PR DESCRIPTION
Removed todos and questions sections from the PR template.
