### PR TITLE
Change to bleeding edge `molfeat` to supress sklearn warnings

### DIFF
--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -20,7 +20,6 @@ dependencies:
   - matplotlib
   - mdanalysis
   - modal
-  - molfeat
   - mordredcommunity
   - numpy
   - pandas
@@ -55,3 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
+    - molfeat

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - molfeat
+    - git@github.com:datamol-io/molfeat.git

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - git@github.com:datamol-io/molfeat.git
+    - git+https://github.com:datamol-io/molfeat.git@main

--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - git+https://github.com:datamol-io/molfeat.git@main
+    - git+https://github.com/OpenADMET/molfeat.git@main

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -20,7 +20,6 @@ dependencies:
   - matplotlib
   - mdanalysis
   - modal
-  - molfeat
   - mordredcommunity
   - numpy
   - pandas
@@ -55,3 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
+    - molfeat

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - molfeat
+    - git@github.com:datamol-io/molfeat.git

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - git@github.com:datamol-io/molfeat.git
+    - git+https://github.com:datamol-io/molfeat.git@main

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -54,4 +54,4 @@ dependencies:
     - phx-class-registry
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
-    - git+https://github.com:datamol-io/molfeat.git@main
+    - git+https://github.com/OpenADMET/molfeat.git@main


### PR DESCRIPTION
## Description
Fixes #210 

Warnings abound when using molfeat. This has been fixed upstream but there has been no release. Lets try switch to a bleeding edge version. 

## Status
- [X] Ready to go


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
