### PR TITLE
Fix UnscaleTransform identity when no scaler is provided

### DIFF
--- a/openadmet/models/architecture/chemprop.py
+++ b/openadmet/models/architecture/chemprop.py
@@ -412,9 +412,9 @@ class ChemPropModel(LightningModelBase):
         if scaler is not None:
             output_transform = nn.UnscaleTransform.from_standard_scaler(scaler)
         elif self.normalized_targets:
-            # Expects the targets to be normalized, likely to be loaded from state dict
+            # Identity placeholder (mean=0, scale=1); real parameters are loaded from checkpoint
             output_transform = nn.UnscaleTransform(
-                [1] * self.n_tasks, [0] * self.n_tasks
+                [0] * self.n_tasks, [1] * self.n_tasks
             )
         else:
             output_transform = None

--- a/openadmet/models/tests/unit/models/test_chemprop.py
+++ b/openadmet/models/tests/unit/models/test_chemprop.py
@@ -193,7 +193,9 @@ def test_chemprop_get_output_transform():
     assert isinstance(transform, nn.UnscaleTransform)
     transform.eval()
     x = torch.tensor([[3.5]])
-    assert transform(x) == pytest.approx(3.5), "no-scaler transform must pass predictions through unchanged"
+    assert transform(x) == pytest.approx(3.5), (
+        "no-scaler transform must pass predictions through unchanged"
+    )
 
     # Case 3: normalized_targets=False, no scaler
     model.normalized_targets = False

--- a/openadmet/models/tests/unit/models/test_chemprop.py
+++ b/openadmet/models/tests/unit/models/test_chemprop.py
@@ -188,9 +188,12 @@ def test_chemprop_get_output_transform():
     transform = model._get_output_transform(scaler)
     assert isinstance(transform, nn.UnscaleTransform)
 
-    # Case 2: normalized_targets=True (default), no scaler
+    # Case 2: normalized_targets=True (default), no scaler — must be identity, not constant
     transform = model._get_output_transform(None)
     assert isinstance(transform, nn.UnscaleTransform)
+    transform.eval()
+    x = torch.tensor([[3.5]])
+    assert transform(x) == pytest.approx(3.5), "no-scaler transform must pass predictions through unchanged"
 
     # Case 3: normalized_targets=False, no scaler
     model.normalized_targets = False


### PR DESCRIPTION
## Description

`_get_output_transform` returns an `UnscaleTransform` placeholder when `normalized_targets=True` and no scaler is supplied, with the expectation that the transform's buffers will be overwritten when checkpoint weights are loaded. It was constructed as `UnscaleTransform([1]*n_tasks, [0]*n_tasks)`, which computes `X * 0 + 1 = 1.0` at inference regardless of what the model outputs. The correct identity is mean=0, scale=1, giving `X * 1 + 0 = X`. Changed to `UnscaleTransform([0]*n_tasks, [1]*n_tasks)`.

The existing test for this path only asserted `isinstance`; it is extended to verify in eval mode that a non-trivial input passes through unchanged.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.