### PR TITLE
Add TabICL v2 architecture with regression and classification models

### DIFF
--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -45,6 +45,7 @@ dependencies:
     - boto3
     - email-validator
     - phx-class-registry
+    - tabicl
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
     - git+https://github.com/JacksonBurns/neural-pairwise-regression.git

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -45,6 +45,7 @@ dependencies:
     - boto3
     - email-validator
     - phx-class-registry
+    - tabicl
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
     - git+https://github.com/JacksonBurns/neural-pairwise-regression.git

--- a/docs/_api/api/model_architectures/index.rst
+++ b/docs/_api/api/model_architectures/index.rst
@@ -13,5 +13,6 @@ Anvil implemenations of various architectures.
    model_base
    random_forest
    svm
+   tabicl
    tabpfn
    xgboost

--- a/docs/_api/api/model_architectures/tabicl.rst
+++ b/docs/_api/api/model_architectures/tabicl.rst
@@ -1,0 +1,7 @@
+TabICL
+======
+
+.. automodule:: openadmet.models.architecture.tabicl
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/anvil_reference.rst
+++ b/docs/anvil_reference.rst
@@ -304,6 +304,10 @@ Refer to the linked OpenADMET API documentation for detailed information on each
     - scikit-learn `Random Forest classifier <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html>`_ .
   * - :doc:`RFRegressorModel </_api/api/model_architectures/random_forest>`
     - scikit-learn `Random Forest regressor <https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html>`_ .
+  * - :doc:`TabICLClassifierModel </_api/api/model_architectures/tabicl>`
+    - TabICL v2 classification model using the `tabicl <https://pypi.org/project/tabicl/>`_ package.
+  * - :doc:`TabICLRegressorModel </_api/api/model_architectures/tabicl>`
+    - TabICL v2 regression model using the `tabicl <https://pypi.org/project/tabicl/>`_ package.
   * - :doc:`TabPFNClassifierModel </_api/api/model_architectures/tabpfn>`
     - TabPFN classification model using the basic `tabpfn <https://github.com/PriorLabs/TabPFN>`_ implementation.
   * - :doc:`TabPFNRegressorModel </_api/api/model_architectures/tabpfn>`

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -37,6 +37,7 @@ dependencies:
   - pip:
     - email-validator
     - phx-class-registry
+    - tabicl
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - -e ../
     - git+https://github.com/openforcefield/openff-sphinx-theme/@main

--- a/openadmet/models/_registry_loader.py
+++ b/openadmet/models/_registry_loader.py
@@ -15,6 +15,7 @@ _MODELS = [
     "openadmet.models.architecture.nepare",
     "openadmet.models.architecture.rf",
     "openadmet.models.architecture.svm",
+    "openadmet.models.architecture.tabicl",
     "openadmet.models.architecture.tabpfn",
     "openadmet.models.architecture.xgboost",
 ]

--- a/openadmet/models/architecture/tabicl.py
+++ b/openadmet/models/architecture/tabicl.py
@@ -3,8 +3,9 @@
 from typing import ClassVar
 
 import numpy as np
+import torch
 from loguru import logger
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 
 from openadmet.models.architecture.model_base import (
     PickleableModelBase,
@@ -84,6 +85,35 @@ class TabICLModelBase(PickleableModelBase):
     offload_mode: str = Field(
         default="auto", description="Offload mode for large data."
     )
+
+    @field_validator("accelerator")
+    @classmethod
+    def validate_accelerator(cls, value: str) -> str:
+        """
+        Validate that the accelerator resolves to a torch-recognized device.
+
+        TabICL only checks its own ``device`` kwarg at ``fit()`` time, several
+        calls removed from where a bad accelerator was actually supplied, so
+        this reproduces the same ``torch.device()`` check eagerly here.
+
+        Parameters
+        ----------
+        value : str
+            Accelerator value to validate.
+
+        Returns
+        -------
+        str
+            The validated accelerator value.
+
+        """
+        resolved = _resolve_device(value)
+        if resolved is not None:
+            try:
+                torch.device(resolved)
+            except RuntimeError as e:
+                raise ValueError(f"Invalid accelerator {value!r}: {e}") from e
+        return value
 
     @classmethod
     def _get_estimator_class(cls) -> type:

--- a/openadmet/models/architecture/tabicl.py
+++ b/openadmet/models/architecture/tabicl.py
@@ -1,0 +1,229 @@
+"""TabICL model implementations."""
+
+from typing import ClassVar, Literal
+
+import numpy as np
+from loguru import logger
+from pydantic import ConfigDict, Field, field_validator
+
+from openadmet.models.architecture.model_base import PickleableModelBase, models
+
+
+class TabICLModelBase(PickleableModelBase):
+    """
+    Base class for TabICL models.
+
+    Attributes
+    ----------
+    type : ClassVar[str]
+        Model type identifier.
+    accelerator : Literal["cpu", "gpu", "auto"]
+        Device to use for training and prediction. Mapped to ``device`` for TabICL.
+    random_seed : int
+        Random seed for reproducibility. Mapped to ``random_state`` for TabICL.
+    n_estimators : int
+        Number of ensemble members.
+    batch_size : int
+        Ensemble members processed together.
+    use_amp : str
+        Automatic mixed precision mode.
+    use_fa3 : str
+        Flash Attention 3 usage mode.
+    offload_mode : str
+        Offload mode for memory management.
+
+    """
+
+    model_config = ConfigDict(extra="allow")
+    type: ClassVar[str]
+
+    accelerator: Literal["cpu", "gpu", "auto"] = Field(
+        default="auto", description="The device to use for training and prediction."
+    )
+    random_seed: int = Field(default=42, description="Random seed for reproducibility.")
+    n_estimators: int = Field(default=8, description="Number of ensemble members.")
+    batch_size: int = Field(
+        default=1, description="Ensemble batch size for memory control."
+    )
+    use_amp: str = Field(
+        default="auto", description="Automatic mixed precision setting."
+    )
+    use_fa3: str = Field(default="auto", description="Flash Attention 3 setting.")
+    offload_mode: str = Field(
+        default="auto", description="Offload mode for large data."
+    )
+
+    @field_validator("accelerator")
+    @classmethod
+    def validate_accelerator(cls, value: str) -> str:
+        """
+        Validate the accelerator parameter.
+
+        Parameters
+        ----------
+        value : str
+            Accelerator value to validate.
+
+        Returns
+        -------
+        str
+            Validated accelerator value.
+
+        """
+        if value not in ["cpu", "gpu", "auto"]:
+            raise ValueError("Accelerator must be 'cpu', 'gpu' or 'auto'")
+        return value
+
+    @classmethod
+    def _get_estimator_class(cls) -> type:
+        """Return the TabICL estimator class."""
+        raise NotImplementedError
+
+    def _build_kwargs(self) -> dict:
+        """Collect kwargs for the underlying estimator."""
+        accelerator = self.accelerator if self.accelerator != "gpu" else "cuda"
+        data = self.model_dump()
+        # Map public names to TabICL names
+        kwargs = {
+            "n_estimators": data.get("n_estimators", 8),
+            "batch_size": data.get("batch_size", 1),
+            "device": accelerator,
+            "random_state": data.get("random_seed", 42),
+            "use_amp": data.get("use_amp", "auto"),
+            "use_fa3": data.get("use_fa3", "auto"),
+            "offload_mode": data.get("offload_mode", "auto"),
+        }
+        # Allow extra fields but whitelist known TabICL params
+        allowed_extra = {
+            "norm_methods",
+            "feat_shuffle_method",
+            "class_shuffle_method",
+            "outlier_threshold",
+            "softmax_temperature",
+            "average_logits",
+            "support_many_classes",
+            "kv_cache",
+            "model_path",
+            "allow_auto_download",
+            "checkpoint_version",
+            "disk_offload_dir",
+            "n_jobs",
+            "verbose",
+            "inference_config",
+        }
+        for k, v in data.items():
+            if k in {
+                "accelerator",
+                "random_seed",
+                "n_estimators",
+                "batch_size",
+                "use_amp",
+                "use_fa3",
+                "offload_mode",
+            }:
+                continue
+            if k in allowed_extra:
+                kwargs[k] = v
+            else:
+                # Unknown extra field – ignore to avoid passing invalid args to TabICL
+                pass
+        return kwargs
+
+    def build(self) -> None:
+        """Prepare and build the model instance."""
+        if not self.estimator:
+            estimator_cls = self._get_estimator_class()
+            kwargs = self._build_kwargs()
+            self.estimator = estimator_cls(**kwargs)
+        else:
+            logger.warning("Model already exists, skipping build")
+
+    def train(self, X: np.ndarray, y: np.ndarray) -> None:
+        """
+        Train the model.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Training features.
+        y : np.ndarray
+            Training targets.
+
+        """
+        self.build()
+        self.estimator = self.estimator.fit(X, y)
+
+    def predict(self, X: np.ndarray, **kwargs) -> np.ndarray:
+        """
+        Predict using the model.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Input features.
+        kwargs : dict
+            Additional arguments for prediction. Must be empty; unknown kwargs raise TypeError.
+
+        Returns
+        -------
+        np.ndarray
+            Model predictions with shape (n_samples, 1).
+
+        Raises
+        ------
+        ValueError
+            If the model is not trained.
+        TypeError
+            If unknown prediction kwargs are supplied.
+
+        """
+        if not self.estimator:
+            raise ValueError("Model not trained")
+        if kwargs:
+            raise TypeError("TabICL predict does not accept extra kwargs")
+        return np.expand_dims(self.estimator.predict(X), axis=1)
+
+
+@models.register("TabICLRegressorModel")
+class TabICLRegressorModel(TabICLModelBase):
+    """TabICL regression model."""
+
+    type: ClassVar[str] = "TabICLRegressorModel"
+
+    @classmethod
+    def _get_estimator_class(cls) -> type:
+        from tabicl import TabICLRegressor
+
+        return TabICLRegressor
+
+
+@models.register("TabICLClassifierModel")
+class TabICLClassifierModel(TabICLModelBase):
+    """TabICL classification model."""
+
+    type: ClassVar[str] = "TabICLClassifierModel"
+
+    @classmethod
+    def _get_estimator_class(cls) -> type:
+        from tabicl import TabICLClassifier
+
+        return TabICLClassifier
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """
+        Predict class probabilities.
+
+        Parameters
+        ----------
+        X : np.ndarray
+            Input features.
+
+        Returns
+        -------
+        np.ndarray
+            Predicted class probabilities.
+
+        """
+        if not self.estimator:
+            raise ValueError("Model not trained")
+        return self.estimator.predict_proba(X)

--- a/openadmet/models/architecture/tabicl.py
+++ b/openadmet/models/architecture/tabicl.py
@@ -162,7 +162,9 @@ class TabICLModelBase(PickleableModelBase):
         X : np.ndarray
             Input features.
         kwargs : dict
-            Additional arguments for prediction. Must be empty; unknown kwargs raise TypeError.
+            Additional keyword arguments accepted for interface
+            compatibility with the anvil pipeline (e.g. accelerator) and
+            ignored; device placement is fixed at build time.
 
         Returns
         -------
@@ -173,14 +175,10 @@ class TabICLModelBase(PickleableModelBase):
         ------
         ValueError
             If the model is not trained.
-        TypeError
-            If unknown prediction kwargs are supplied.
 
         """
         if not self.estimator:
             raise ValueError("Model not trained")
-        if kwargs:
-            raise TypeError("TabICL predict does not accept extra kwargs")
         return np.expand_dims(self.estimator.predict(X), axis=1)
 
 

--- a/openadmet/models/architecture/tabicl.py
+++ b/openadmet/models/architecture/tabicl.py
@@ -1,12 +1,44 @@
 """TabICL model implementations."""
 
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 import numpy as np
 from loguru import logger
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field
 
-from openadmet.models.architecture.model_base import PickleableModelBase, models
+from openadmet.models.architecture.model_base import (
+    PickleableModelBase,
+    models,
+    seed_to_sklearn_kwargs,
+)
+
+# TabICL's device kwarg accepts anything torch.device() parses (cpu, cuda,
+# cuda:0, mps, xla, ...); these are the two spellings that differ from ours
+_ACCELERATOR_ALIASES = {"gpu": "cuda", "tpu": "xla"}
+
+
+def _resolve_device(accelerator: str) -> str | None:
+    """
+    Resolve an accelerator spelling to a value TabICL's ``device`` kwarg accepts.
+
+    "auto" maps to ``None`` so TabICL runs its own cuda-availability check;
+    trainer aliases map to torch device names, and every other value passes
+    through verbatim.
+
+    Parameters
+    ----------
+    accelerator : str
+        The accelerator spelling to resolve.
+
+    Returns
+    -------
+    str or None
+        A value accepted by TabICL's ``device`` parameter.
+
+    """
+    if accelerator == "auto":
+        return None
+    return _ACCELERATOR_ALIASES.get(accelerator, accelerator)
 
 
 class TabICLModelBase(PickleableModelBase):
@@ -17,7 +49,7 @@ class TabICLModelBase(PickleableModelBase):
     ----------
     type : ClassVar[str]
         Model type identifier.
-    accelerator : Literal["cpu", "gpu", "auto"]
+    accelerator : str
         Device to use for training and prediction. Mapped to ``device`` for TabICL.
     random_seed : int
         Random seed for reproducibility. Mapped to ``random_state`` for TabICL.
@@ -37,7 +69,7 @@ class TabICLModelBase(PickleableModelBase):
     model_config = ConfigDict(extra="allow")
     type: ClassVar[str]
 
-    accelerator: Literal["cpu", "gpu", "auto"] = Field(
+    accelerator: str = Field(
         default="auto", description="The device to use for training and prediction."
     )
     random_seed: int = Field(default=42, description="Random seed for reproducibility.")
@@ -53,27 +85,6 @@ class TabICLModelBase(PickleableModelBase):
         default="auto", description="Offload mode for large data."
     )
 
-    @field_validator("accelerator")
-    @classmethod
-    def validate_accelerator(cls, value: str) -> str:
-        """
-        Validate the accelerator parameter.
-
-        Parameters
-        ----------
-        value : str
-            Accelerator value to validate.
-
-        Returns
-        -------
-        str
-            Validated accelerator value.
-
-        """
-        if value not in ["cpu", "gpu", "auto"]:
-            raise ValueError("Accelerator must be 'cpu', 'gpu' or 'auto'")
-        return value
-
     @classmethod
     def _get_estimator_class(cls) -> type:
         """Return the TabICL estimator class."""
@@ -81,54 +92,8 @@ class TabICLModelBase(PickleableModelBase):
 
     def _build_kwargs(self) -> dict:
         """Collect kwargs for the underlying estimator."""
-        accelerator = self.accelerator if self.accelerator != "gpu" else "cuda"
-        data = self.model_dump()
-
-        # Map public names to TabICL names
-        kwargs = {
-            "n_estimators": data.get("n_estimators", 8),
-            "batch_size": data.get("batch_size", 1),
-            "device": accelerator,
-            "random_state": data.get("random_seed", 42),
-            "use_amp": data.get("use_amp", "auto"),
-            "use_fa3": data.get("use_fa3", "auto"),
-            "offload_mode": data.get("offload_mode", "auto"),
-        }
-
-        # Allow extra fields but whitelist known TabICL params
-        allowed_extra = {
-            "norm_methods",
-            "feat_shuffle_method",
-            "class_shuffle_method",
-            "outlier_threshold",
-            "softmax_temperature",
-            "average_logits",
-            "support_many_classes",
-            "kv_cache",
-            "model_path",
-            "allow_auto_download",
-            "checkpoint_version",
-            "disk_offload_dir",
-            "n_jobs",
-            "verbose",
-            "inference_config",
-        }
-        for k, v in data.items():
-            if k in {
-                "accelerator",
-                "random_seed",
-                "n_estimators",
-                "batch_size",
-                "use_amp",
-                "use_fa3",
-                "offload_mode",
-            }:
-                continue
-            if k in allowed_extra:
-                kwargs[k] = v
-            else:
-                # Unknown extra field, ignore to avoid passing invalid args to TabICL
-                pass
+        kwargs = seed_to_sklearn_kwargs(self.model_dump())
+        kwargs["device"] = _resolve_device(kwargs.pop("accelerator"))
         return kwargs
 
     def build(self) -> None:

--- a/openadmet/models/architecture/tabicl.py
+++ b/openadmet/models/architecture/tabicl.py
@@ -83,6 +83,7 @@ class TabICLModelBase(PickleableModelBase):
         """Collect kwargs for the underlying estimator."""
         accelerator = self.accelerator if self.accelerator != "gpu" else "cuda"
         data = self.model_dump()
+
         # Map public names to TabICL names
         kwargs = {
             "n_estimators": data.get("n_estimators", 8),
@@ -93,6 +94,7 @@ class TabICLModelBase(PickleableModelBase):
             "use_fa3": data.get("use_fa3", "auto"),
             "offload_mode": data.get("offload_mode", "auto"),
         }
+
         # Allow extra fields but whitelist known TabICL params
         allowed_extra = {
             "norm_methods",
@@ -125,7 +127,7 @@ class TabICLModelBase(PickleableModelBase):
             if k in allowed_extra:
                 kwargs[k] = v
             else:
-                # Unknown extra field – ignore to avoid passing invalid args to TabICL
+                # Unknown extra field, ignore to avoid passing invalid args to TabICL
                 pass
         return kwargs
 

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -1,0 +1,133 @@
+"""Unit tests for TabICL models."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from openadmet.models.architecture.tabicl import (
+    TabICLClassifierModel,
+    TabICLModelBase,
+    TabICLRegressorModel,
+)
+
+
+def test_tabicl_model_base_fields():
+    """Verify default fields and mapping."""
+    model = TabICLModelBase()
+    assert model.random_seed == 42
+    assert model.accelerator == "auto"
+    assert model.n_estimators == 8
+    assert model.batch_size == 1
+    assert model.use_amp == "auto"
+    assert model.use_fa3 == "auto"
+    assert model.offload_mode == "auto"
+
+
+def test_accelerator_validator():
+    """Validate accelerator values."""
+    with pytest.raises(ValueError):
+        TabICLModelBase(accelerator="invalid")
+
+
+def test_build_kwargs_mapping():
+    """Ensure public names map to estimator names."""
+    model = TabICLRegressorModel(
+        random_seed=123,
+        accelerator="gpu",
+        n_estimators=4,
+        batch_size=2,
+        use_amp="no",
+        use_fa3="yes",
+        offload_mode="disk",
+        norm_methods=["standard"],
+    )
+    kwargs = model._build_kwargs()
+    assert kwargs["random_state"] == 123
+    assert kwargs["device"] == "cuda"
+    assert kwargs["n_estimators"] == 4
+    assert kwargs["batch_size"] == 2
+    assert kwargs["use_amp"] == "no"
+    assert kwargs["use_fa3"] == "yes"
+    assert kwargs["offload_mode"] == "disk"
+    assert kwargs["norm_methods"] == ["standard"]
+    # Unknown extra fields should be ignored
+    model2 = TabICLRegressorModel(extra_param="keep me")
+    kwargs2 = model2._build_kwargs()
+    assert "extra_param" not in kwargs2
+
+
+@patch("tabicl.TabICLRegressor")
+def test_regressor_build_and_train(mock_est_cls):
+    """Test build and train flow with mocked estimator."""
+    mock_est = MagicMock()
+    mock_est.fit.return_value = mock_est
+    mock_est_cls.return_value = mock_est
+
+    model = TabICLRegressorModel(random_seed=1, accelerator="cpu")
+    model.build()
+    assert model.estimator is mock_est
+
+    X = np.zeros((5, 3))
+    y = np.zeros(5)
+    model.train(X, y)
+    mock_est.fit.assert_called_once_with(X, y)
+
+
+@patch("tabicl.TabICLRegressor")
+def test_regressor_predict_shape(mock_est_cls):
+    """Test predict returns correct shape."""
+    mock_est = MagicMock()
+    mock_est.predict.return_value = np.array([0.1, 0.2, 0.3])
+    mock_est_cls.return_value = mock_est
+
+    model = TabICLRegressorModel()
+    model.build()
+    X = np.zeros((3, 2))
+    preds = model.predict(X)
+    assert preds.shape == (3, 1)
+    np.testing.assert_array_equal(preds.ravel(), [0.1, 0.2, 0.3])
+
+
+def test_predict_raises_if_not_trained():
+    """Predict should raise when model is not built."""
+    model = TabICLRegressorModel()
+    with pytest.raises(ValueError):
+        model.predict(np.zeros((1, 2)))
+
+
+def test_predict_rejects_kwargs():
+    """Predict should reject unknown kwargs."""
+    from unittest.mock import MagicMock
+
+    mock_est = MagicMock()
+    mock_est.predict.return_value = np.array([0.1])
+    model = TabICLRegressorModel()
+    model.estimator = mock_est
+    with pytest.raises(TypeError):
+        model.predict(np.zeros((1, 2)), unknown=1)
+
+
+@patch("tabicl.TabICLClassifier")
+def test_classifier_predict_proba(mock_est_cls):
+    """Test classifier predict_proba delegation."""
+    mock_est = MagicMock()
+    mock_est.predict_proba.return_value = np.array([[0.2, 0.8]])
+    mock_est_cls.return_value = mock_est
+
+    model = TabICLClassifierModel()
+    model.build()
+    X = np.zeros((1, 2))
+    proba = model.predict_proba(X)
+    np.testing.assert_array_equal(proba, [[0.2, 0.8]])
+
+
+def test_registry_names():
+    """Ensure models are registered with correct keys."""
+    from openadmet.models.architecture.model_base import models
+
+    assert "TabICLRegressorModel" in models._registry
+    assert "TabICLClassifierModel" in models._registry
+    assert models.get_class("TabICLRegressorModel") is TabICLRegressorModel
+    assert models.get_class("TabICLClassifierModel") is TabICLClassifierModel

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -97,16 +97,20 @@ def test_predict_raises_if_not_trained():
         model.predict(np.zeros((1, 2)))
 
 
-def test_predict_rejects_kwargs():
-    """Predict should reject unknown kwargs."""
-    from unittest.mock import MagicMock
+def test_predict_accepts_pipeline_kwargs():
+    """predict must accept extra kwargs such as accelerator and ignore them, since the anvil inference path passes them."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 4))
+    y = rng.normal(size=20)
 
-    mock_est = MagicMock()
-    mock_est.predict.return_value = np.array([0.1])
-    model = TabICLRegressorModel()
-    model.estimator = mock_est
-    with pytest.raises(TypeError):
-        model.predict(np.zeros((1, 2)), unknown=1)
+    model = TabICLRegressorModel(n_estimators=1, accelerator="cpu")
+    model.train(X, y)
+
+    out_plain = model.predict(X)
+    out_pipelined = model.predict(X, accelerator="cpu")
+
+    assert out_plain.shape == (20, 1)
+    np.testing.assert_allclose(out_plain, out_pipelined, rtol=1e-12)
 
 
 @patch("tabicl.TabICLClassifier")

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -24,6 +24,18 @@ def test_tabicl_model_base_fields():
     assert model.offload_mode == "auto"
 
 
+def test_accelerator_validator_rejects_bad_value():
+    """An accelerator torch.device() cannot parse must fail at construction time."""
+    with pytest.raises(ValueError, match="Invalid accelerator"):
+        TabICLModelBase(accelerator="not_a_real_device")
+
+
+def test_accelerator_validator_accepts_known_values():
+    """cpu, gpu, auto, and unaliased torch device spellings must all construct cleanly."""
+    for accelerator in ["cpu", "gpu", "auto", "mps", "cuda:0"]:
+        TabICLModelBase(accelerator=accelerator)
+
+
 def test_build_kwargs_mapping():
     """Ensure public names map to estimator names."""
     model = TabICLRegressorModel(

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -24,12 +24,6 @@ def test_tabicl_model_base_fields():
     assert model.offload_mode == "auto"
 
 
-def test_accelerator_validator():
-    """Validate accelerator values."""
-    with pytest.raises(ValueError):
-        TabICLModelBase(accelerator="invalid")
-
-
 def test_build_kwargs_mapping():
     """Ensure public names map to estimator names."""
     model = TabICLRegressorModel(
@@ -52,10 +46,33 @@ def test_build_kwargs_mapping():
     assert kwargs["offload_mode"] == "disk"
     assert kwargs["norm_methods"] == ["standard"]
 
-    # Unknown extra fields should be ignored
-    model2 = TabICLRegressorModel(extra_param="keep me")
-    kwargs2 = model2._build_kwargs()
-    assert "extra_param" not in kwargs2
+
+def test_build_kwargs_maps_auto_accelerator_to_none_device():
+    """The "auto" accelerator must resolve to None so TabICL runs its own device detection."""
+    model = TabICLRegressorModel(accelerator="auto")
+    kwargs = model._build_kwargs()
+    assert kwargs["device"] is None
+
+
+def test_build_kwargs_maps_tpu_accelerator_to_xla_device():
+    """The "tpu" accelerator must resolve to the torch device spelling "xla"."""
+    model = TabICLRegressorModel(accelerator="tpu")
+    kwargs = model._build_kwargs()
+    assert kwargs["device"] == "xla"
+
+
+def test_build_kwargs_passes_through_unmapped_accelerator():
+    """Accelerator spellings with no alias, e.g. "mps", pass through unchanged."""
+    model = TabICLRegressorModel(accelerator="mps")
+    kwargs = model._build_kwargs()
+    assert kwargs["device"] == "mps"
+
+
+def test_build_raises_on_unsupported_kwarg():
+    """Unsupported extra fields must fail loudly at build time, not be dropped."""
+    model = TabICLRegressorModel(not_a_real_param="keep me")
+    with pytest.raises(TypeError):
+        model.build()
 
 
 def test_regressor_build_train_predict():

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from unittest.mock import MagicMock, patch
 
 from openadmet.models.architecture.tabicl import (
     TabICLClassifierModel,
@@ -58,36 +57,22 @@ def test_build_kwargs_mapping():
     assert "extra_param" not in kwargs2
 
 
-@patch("tabicl.TabICLRegressor")
-def test_regressor_build_and_train(mock_est_cls):
-    """Test build and train flow with mocked estimator."""
-    mock_est = MagicMock()
-    mock_est.fit.return_value = mock_est
-    mock_est_cls.return_value = mock_est
+def test_regressor_build_train_predict():
+    """build must construct the TabICL estimator, and train plus predict must produce 2D predictions."""
+    from tabicl import TabICLRegressor
 
-    model = TabICLRegressorModel(random_seed=1, accelerator="cpu")
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 4))
+    y = rng.normal(size=20)
+
+    model = TabICLRegressorModel(n_estimators=1, accelerator="cpu")
     model.build()
-    assert model.estimator is mock_est
+    assert isinstance(model.estimator, TabICLRegressor)
 
-    X = np.zeros((5, 3))
-    y = np.zeros(5)
     model.train(X, y)
-    mock_est.fit.assert_called_once_with(X, y)
-
-
-@patch("tabicl.TabICLRegressor")
-def test_regressor_predict_shape(mock_est_cls):
-    """Test predict returns correct shape."""
-    mock_est = MagicMock()
-    mock_est.predict.return_value = np.array([0.1, 0.2, 0.3])
-    mock_est_cls.return_value = mock_est
-
-    model = TabICLRegressorModel()
-    model.build()
-    X = np.zeros((3, 2))
     preds = model.predict(X)
-    assert preds.shape == (3, 1)
-    np.testing.assert_array_equal(preds.ravel(), [0.1, 0.2, 0.3])
+    assert preds.shape == (20, 1)
+    assert np.isfinite(preds).all()
 
 
 def test_predict_raises_if_not_trained():
@@ -113,18 +98,19 @@ def test_predict_accepts_pipeline_kwargs():
     np.testing.assert_allclose(out_plain, out_pipelined, rtol=1e-12)
 
 
-@patch("tabicl.TabICLClassifier")
-def test_classifier_predict_proba(mock_est_cls):
-    """Test classifier predict_proba delegation."""
-    mock_est = MagicMock()
-    mock_est.predict_proba.return_value = np.array([[0.2, 0.8]])
-    mock_est_cls.return_value = mock_est
+def test_classifier_predict_proba():
+    """Classifier proba must return one row of class probabilities per sample."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 4))
+    y = np.array([0, 1] * 10)
 
-    model = TabICLClassifierModel()
-    model.build()
-    X = np.zeros((1, 2))
+    model = TabICLClassifierModel(n_estimators=1, accelerator="cpu")
+    model.train(X, y)
     proba = model.predict_proba(X)
-    np.testing.assert_array_equal(proba, [[0.2, 0.8]])
+
+    assert proba.shape == (20, 2)
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, rtol=1e-5)
 
 
 def test_registry_names():

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -51,6 +51,7 @@ def test_build_kwargs_mapping():
     assert kwargs["use_fa3"] == "yes"
     assert kwargs["offload_mode"] == "disk"
     assert kwargs["norm_methods"] == ["standard"]
+
     # Unknown extra fields should be ignored
     model2 = TabICLRegressorModel(extra_param="keep me")
     kwargs2 = model2._build_kwargs()

--- a/openadmet/models/tests/unit/models/test_tabicl.py
+++ b/openadmet/models/tests/unit/models/test_tabicl.py
@@ -12,6 +12,24 @@ from openadmet.models.architecture.tabicl import (
 )
 
 
+@pytest.fixture
+def regression_data():
+    """20-sample, 4-feature regression data for train/predict tests."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 4))
+    y = rng.normal(size=20)
+    return X, y
+
+
+@pytest.fixture
+def classification_data():
+    """20-sample, 4-feature, 2-class classification data for train/predict tests."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 4))
+    y = np.array([0, 1] * 10)
+    return X, y
+
+
 def test_tabicl_model_base_fields():
     """Verify default fields and mapping."""
     model = TabICLModelBase()
@@ -30,17 +48,17 @@ def test_accelerator_validator_rejects_bad_value():
         TabICLModelBase(accelerator="not_a_real_device")
 
 
-def test_accelerator_validator_accepts_known_values():
+@pytest.mark.parametrize("accelerator", ["cpu", "gpu", "auto", "mps", "cuda:0"])
+def test_accelerator_validator_accepts_known_values(accelerator):
     """cpu, gpu, auto, and unaliased torch device spellings must all construct cleanly."""
-    for accelerator in ["cpu", "gpu", "auto", "mps", "cuda:0"]:
-        TabICLModelBase(accelerator=accelerator)
+    TabICLModelBase(accelerator=accelerator)
 
 
 def test_build_kwargs_mapping():
     """Ensure public names map to estimator names."""
     model = TabICLRegressorModel(
         random_seed=123,
-        accelerator="gpu",
+        accelerator="cpu",
         n_estimators=4,
         batch_size=2,
         use_amp="no",
@@ -50,7 +68,6 @@ def test_build_kwargs_mapping():
     )
     kwargs = model._build_kwargs()
     assert kwargs["random_state"] == 123
-    assert kwargs["device"] == "cuda"
     assert kwargs["n_estimators"] == 4
     assert kwargs["batch_size"] == 2
     assert kwargs["use_amp"] == "no"
@@ -59,25 +76,22 @@ def test_build_kwargs_mapping():
     assert kwargs["norm_methods"] == ["standard"]
 
 
-def test_build_kwargs_maps_auto_accelerator_to_none_device():
-    """The "auto" accelerator must resolve to None so TabICL runs its own device detection."""
-    model = TabICLRegressorModel(accelerator="auto")
+@pytest.mark.parametrize(
+    "accelerator,expected_device",
+    [
+        ("gpu", "cuda"),
+        ("auto", None),
+        ("tpu", "xla"),
+        ("mps", "mps"),
+        ("cuda:0", "cuda:0"),
+    ],
+)
+def test_build_kwargs_maps_accelerator_to_device(accelerator, expected_device):
+    """Accelerator aliases resolve to torch device names; "auto" maps to None so
+    TabICL runs its own device detection, and unaliased spellings pass through."""
+    model = TabICLRegressorModel(accelerator=accelerator)
     kwargs = model._build_kwargs()
-    assert kwargs["device"] is None
-
-
-def test_build_kwargs_maps_tpu_accelerator_to_xla_device():
-    """The "tpu" accelerator must resolve to the torch device spelling "xla"."""
-    model = TabICLRegressorModel(accelerator="tpu")
-    kwargs = model._build_kwargs()
-    assert kwargs["device"] == "xla"
-
-
-def test_build_kwargs_passes_through_unmapped_accelerator():
-    """Accelerator spellings with no alias, e.g. "mps", pass through unchanged."""
-    model = TabICLRegressorModel(accelerator="mps")
-    kwargs = model._build_kwargs()
-    assert kwargs["device"] == "mps"
+    assert kwargs["device"] == expected_device
 
 
 def test_build_raises_on_unsupported_kwarg():
@@ -87,14 +101,11 @@ def test_build_raises_on_unsupported_kwarg():
         model.build()
 
 
-def test_regressor_build_train_predict():
+def test_regressor_build_train_predict(regression_data):
     """build must construct the TabICL estimator, and train plus predict must produce 2D predictions."""
     from tabicl import TabICLRegressor
 
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(20, 4))
-    y = rng.normal(size=20)
-
+    X, y = regression_data
     model = TabICLRegressorModel(n_estimators=1, accelerator="cpu")
     model.build()
     assert isinstance(model.estimator, TabICLRegressor)
@@ -105,19 +116,17 @@ def test_regressor_build_train_predict():
     assert np.isfinite(preds).all()
 
 
-def test_predict_raises_if_not_trained():
+@pytest.mark.parametrize("model_cls", [TabICLRegressorModel, TabICLClassifierModel])
+def test_predict_raises_if_not_trained(model_cls):
     """Predict should raise when model is not built."""
-    model = TabICLRegressorModel()
+    model = model_cls()
     with pytest.raises(ValueError):
         model.predict(np.zeros((1, 2)))
 
 
-def test_predict_accepts_pipeline_kwargs():
+def test_predict_accepts_pipeline_kwargs(regression_data):
     """predict must accept extra kwargs such as accelerator and ignore them, since the anvil inference path passes them."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(20, 4))
-    y = rng.normal(size=20)
-
+    X, y = regression_data
     model = TabICLRegressorModel(n_estimators=1, accelerator="cpu")
     model.train(X, y)
 
@@ -128,12 +137,9 @@ def test_predict_accepts_pipeline_kwargs():
     np.testing.assert_allclose(out_plain, out_pipelined, rtol=1e-12)
 
 
-def test_classifier_predict_proba():
+def test_classifier_predict_proba(classification_data):
     """Classifier proba must return one row of class probabilities per sample."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(20, 4))
-    y = np.array([0, 1] * 10)
-
+    X, y = classification_data
     model = TabICLClassifierModel(n_estimators=1, accelerator="cpu")
     model.train(X, y)
     proba = model.predict_proba(X)


### PR DESCRIPTION
## Description

Adds TabICL v2 support via openadmet/models/architecture/tabicl.py with TabICLRegressorModel and TabICLClassifierModel. Adds registry entry, conda env updates, docs requirements, and unit tests.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

---
**Note to Contributors:** We reserve the right to close PRs without review if they appear to lack human validation or do not meet the quality standards described in our `CONTRIBUTING.md`.