### PR TITLE
Rename butina cutoff kwarg to dist_cutoff

### DIFF
--- a/openadmet/models/split/cluster.py
+++ b/openadmet/models/split/cluster.py
@@ -71,7 +71,7 @@ class ClusterSplitter(SplitterBase):
         if self.method == "butina":
             from useful_rdkit_utils import get_butina_clusters
 
-            clusters = get_butina_clusters(X, cutoff=self.butina_cutoff)
+            clusters = get_butina_clusters(X, dist_cutoff=self.butina_cutoff)
         elif self.method == "bemis-murcko":
             from useful_rdkit_utils import get_bemis_murcko_clusters
 


### PR DESCRIPTION
## Description

The `useful_rdkit_utils` dependency is pinned to a moving branch (`git+https://github.com/PatWalters/useful_rdkit_utils.git@master`). Upstream renamed the `get_butina_clusters` parameter from `cutoff` to `dist_cutoff`. Because the pin is a branch rather than a fixed ref, any freshly built environment now resolves the newer upstream commit, and the call site in `openadmet/models/split/cluster.py` raised:

```
TypeError: get_butina_clusters() got an unexpected keyword argument 'cutoff'
```

This surfaced as `test_cluster_split_synthetic_data[butina]` failing on `main` after a clean CI environment build, even though it passed on caches holding the older upstream. This changes only the keyword at the call site to match the current upstream API. The dependency ref is intentionally left unpinned per the scope of this fix; the upstream return type also changed from `List[int]` to `np.ndarray`, which the existing downstream cluster handling accepts unchanged.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [x] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [x] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [x] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [x] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [x] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
