### PR TITLE
Add MonroeFeaturizer for Monroe foundation model embeddings

### DIFF
--- a/devtools/conda-envs/openadmet-models-gpu.yaml
+++ b/devtools/conda-envs/openadmet-models-gpu.yaml
@@ -49,6 +49,7 @@ dependencies:
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
     - git+https://github.com/JacksonBurns/neural-pairwise-regression.git
+    - git+https://github.com/blazejba/monroe.git@3e138d9bb947e89c9f8faf7db86210385d6657c2
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0

--- a/devtools/conda-envs/openadmet-models.yaml
+++ b/devtools/conda-envs/openadmet-models.yaml
@@ -49,6 +49,7 @@ dependencies:
     - tabpfn-extensions
     - git+https://github.com/PriorLabs/TabPFN.git@main
     - git+https://github.com/JacksonBurns/neural-pairwise-regression.git
+    - git+https://github.com/blazejba/monroe.git@3e138d9bb947e89c9f8faf7db86210385d6657c2
     - git+https://github.com/OpenADMET/molfeat.git@main
     - git+https://github.com/PatWalters/useful_rdkit_utils.git@master
     - setuptools <82.0.0

--- a/docs/_api/api/featurization/index.rst
+++ b/docs/_api/api/featurization/index.rst
@@ -8,6 +8,7 @@ Featurizers for input data for anvil models.
 
    chemprop
    chemeleon_embedding
+   monroe
    feature_combiner
    fingerprints
    descriptors

--- a/docs/_api/api/featurization/monroe.rst
+++ b/docs/_api/api/featurization/monroe.rst
@@ -1,0 +1,7 @@
+Monroe Embeddings
+=================
+
+.. automodule:: openadmet.models.features.monroe
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/anvil_reference.rst
+++ b/docs/anvil_reference.rst
@@ -245,6 +245,8 @@ while traditional machine learning models return a a 2D ``NumPy`` array or ``pan
     - Converts SMILES strings into a ChemProp compatible PyTorch DataLoader.
   * - :doc:`CheMeleonEmbeddingFeaturizer </_api/api/featurization/chemeleon_embedding>`
     - Extracts pooled MPNN embeddings from the pretrained `CheMeleon <https://github.com/JacksonBurns/chemeleon>`_ foundation model as a 2D NumPy array.
+  * - :doc:`MonroeFeaturizer </_api/api/featurization/monroe>`
+    - Extracts graph-level embeddings from the pretrained `Monroe <https://github.com/blazejba/monroe>`_ foundation model as a 2D NumPy array. Requires the ``monroe`` package, which installs from GitHub rather than PyPI. Embeddings are stochastic across runs, so features must be materialized once and reused.
   * - :doc:`DescriptorFeaturizer </_api/api/featurization/descriptors>`
     - Uses the  `molfeat <https://github.com/datamol-io/molfeat>`_ library to compute molecular descriptors.
   * - :doc:`FingerprintFeaturizer </_api/api/featurization/fingerprints>`

--- a/openadmet/models/_registry_loader.py
+++ b/openadmet/models/_registry_loader.py
@@ -33,6 +33,7 @@ _FEATURIZERS = [
     "openadmet.models.features.combine",
     "openadmet.models.features.molfeat_fingerprint",
     "openadmet.models.features.molfeat_properties",
+    "openadmet.models.features.monroe",
     "openadmet.models.features.null_featurizer",
     "openadmet.models.features.trained_model",
 ]

--- a/openadmet/models/features/monroe.py
+++ b/openadmet/models/features/monroe.py
@@ -1,0 +1,634 @@
+"""Monroe foundation model embedding featurizer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import ClassVar
+from urllib.request import urlretrieve
+
+import numpy as np
+import torch
+from loguru import logger
+from pydantic import Field, PrivateAttr, field_validator, model_validator
+
+from openadmet.models.architecture.chemprop import _resolve_device
+from openadmet.models.features.feature_base import FeaturizerBase, featurizers
+
+# The monroe package and the checkpoint are pinned to the same commit, because the
+# embedding is a function of both the weights and the graph-construction code
+_MONROE_CKPT_COMMIT = "3e138d9bb947e89c9f8faf7db86210385d6657c2"
+
+_MONROE_INSTALL_HINT = (
+    "MonroeFeaturizer requires the monroe package, which is not published on PyPI. "
+    "Install it with: pip install "
+    f"git+https://github.com/blazejba/monroe.git@{_MONROE_CKPT_COMMIT}"
+)
+
+_MONROE_CONFIG_URL = (
+    f"https://raw.githubusercontent.com/blazejba/monroe/{_MONROE_CKPT_COMMIT}"
+    "/checkpoint/config.json"
+)
+
+# weights.pt is Git LFS tracked, so raw.githubusercontent.com serves a pointer file
+# instead of the weights; the media endpoint serves the real bytes
+_MONROE_WEIGHTS_URL = (
+    f"https://media.githubusercontent.com/media/blazejba/monroe/{_MONROE_CKPT_COMMIT}"
+    "/checkpoint/weights.pt"
+)
+_MONROE_WEIGHTS_SHA256 = (
+    "df996e8e98b12a3cda5fe5acbef3e1e9a4ea31946d3736461cd07e53a5bf205a"
+)
+_MONROE_WEIGHTS_BYTES = 300057823
+
+# Width of the pinned checkpoint's graph-level embedding, which is its encoder
+# hidden_dim; lets an empty input be shaped without downloading anything
+_MONROE_EMBEDDING_DIM = 720
+
+# Written last, once both files are promoted, so its presence and contents are what
+# distinguish a complete cache entry from a partial or tampered one
+_VERIFIED_MARKER = "weights.sha256"
+
+# Cap on how many failed SMILES the drop warning names before it elides the rest
+_MAX_REPORTED_DROPS = 10
+
+
+def _import_monroe() -> tuple[
+    Callable[..., torch.nn.Module], Callable[..., dict[str, np.ndarray]]
+]:
+    """
+    Import monroe's checkpoint loader and embedder, deferring the cost to first use.
+
+    Importing lazily is what lets this module be imported, and therefore
+    registered, in an environment where monroe is not installed.
+
+    Returns
+    -------
+    tuple
+        The ``(load_ckpt, embed_smiles)`` callables from monroe.
+
+    Raises
+    ------
+    ImportError
+        If monroe is not installed, re-raised with installation instructions.
+
+    """
+    try:
+        from monroe.eval.embed import embed_smiles
+        from monroe.model.ckpt import load_ckpt
+    except ImportError as e:
+        raise ImportError(_MONROE_INSTALL_HINT) from e
+    return load_ckpt, embed_smiles
+
+
+def _sha256(path: Path) -> str:
+    """
+    Return the hex sha256 digest of a file, read in chunks.
+
+    Parameters
+    ----------
+    path : Path
+        File to digest.
+
+    Returns
+    -------
+    str
+        Lowercase hex digest.
+
+    """
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_verified_cache(ckpt_dir: Path) -> bool:
+    """
+    Report whether a cache directory holds a complete, digest-matched checkpoint.
+
+    The marker records the digest of the weights that were promoted, so a cache
+    entry that was truncated, half-written, or replaced on disk after the fact
+    fails this check rather than being trusted forever on its size alone.
+
+    Parameters
+    ----------
+    ckpt_dir : Path
+        Candidate cache directory.
+
+    Returns
+    -------
+    bool
+        True when the directory can be handed to monroe as-is.
+
+    """
+    marker = ckpt_dir / _VERIFIED_MARKER
+    weights = ckpt_dir / "weights.pt"
+
+    if not (
+        marker.is_file() and weights.is_file() and (ckpt_dir / "config.json").is_file()
+    ):
+        return False
+
+    # Size is the cheap guard against a weights file replaced since promotion;
+    # the marker is what ties the entry to the pinned digest
+    if weights.stat().st_size != _MONROE_WEIGHTS_BYTES:
+        return False
+
+    return marker.read_text().strip() == _MONROE_WEIGHTS_SHA256
+
+
+def _fetch_to(url: str, destination: Path) -> None:
+    """
+    Download a URL into place through a process-private scratch file.
+
+    Promoting by rename means a concurrent reader sees either the previous
+    contents or the complete new ones, never a partial transfer.
+
+    Parameters
+    ----------
+    url : str
+        Source URL.
+    destination : Path
+        Final path to promote the download to.
+
+    """
+    scratch = destination.with_name(f"{destination.name}.{os.getpid()}.part")
+    try:
+        urlretrieve(url, scratch)
+        scratch.replace(destination)
+    finally:
+        scratch.unlink(missing_ok=True)
+
+
+def _download_monroe_checkpoint(cache_root: Path | None = None) -> Path:
+    """
+    Fetch the published Monroe checkpoint, returning a directory monroe can load.
+
+    Parameters
+    ----------
+    cache_root : Path, optional
+        Root under which checkpoints are cached, by default ``~/.openadmet``.
+
+    Returns
+    -------
+    Path
+        Directory holding ``config.json`` and ``weights.pt``.
+
+    Raises
+    ------
+    RuntimeError
+        If the downloaded weights do not match the expected sha256 digest.
+
+    """
+    root = cache_root if cache_root is not None else Path.home() / ".openadmet"
+    ckpt_dir = root / "monroe" / _MONROE_CKPT_COMMIT
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    if _is_verified_cache(ckpt_dir):
+        logger.info("Loading cached Monroe checkpoint from {}", ckpt_dir)
+        return ckpt_dir
+
+    logger.info(
+        "Downloading Monroe checkpoint ({:.0f} MB) to {}",
+        _MONROE_WEIGHTS_BYTES / 1e6,
+        ckpt_dir,
+    )
+
+    # The marker is removed first, so an interrupted re-download cannot leave the
+    # previous marker vouching for the new weights
+    marker_path = ckpt_dir / _VERIFIED_MARKER
+    marker_path.unlink(missing_ok=True)
+
+    _fetch_to(_MONROE_CONFIG_URL, ckpt_dir / "config.json")
+
+    weights_path = ckpt_dir / "weights.pt"
+    scratch = weights_path.with_name(f"weights.pt.{os.getpid()}.part")
+    try:
+        urlretrieve(_MONROE_WEIGHTS_URL, scratch)
+
+        digest = _sha256(scratch)
+        if digest != _MONROE_WEIGHTS_SHA256:
+            raise RuntimeError(
+                f"Monroe checkpoint download from {_MONROE_WEIGHTS_URL} is corrupt: "
+                f"expected sha256 {_MONROE_WEIGHTS_SHA256}, got {digest}. "
+                "The partial download has been removed; retry the featurization."
+            )
+
+        scratch.replace(weights_path)
+    finally:
+        scratch.unlink(missing_ok=True)
+
+    marker_path.write_text(_MONROE_WEIGHTS_SHA256)
+    return ckpt_dir
+
+
+def _load_encoder(checkpoint_dir: Path, use_ema: bool) -> torch.nn.Module:
+    """
+    Build the frozen Monroe encoder from a checkpoint directory.
+
+    Parameters
+    ----------
+    checkpoint_dir : Path
+        Directory holding ``config.json`` and ``weights.pt``.
+    use_ema : bool
+        Whether to load the exponential-moving-average weights.
+
+    Returns
+    -------
+    torch.nn.Module
+        The encoder, as returned by monroe's ``load_ckpt``.
+
+    """
+    load_ckpt, _ = _import_monroe()
+    return load_ckpt(str(checkpoint_dir), use_ema=use_ema)
+
+
+def _embed_smiles(
+    smiles: list[str],
+    encoder: torch.nn.Module,
+    device: str,
+    batch_size: int,
+    n_workers: int,
+) -> dict[str, np.ndarray]:
+    """
+    Embed SMILES with monroe, returning its SMILES-keyed mapping unchanged.
+
+    Parameters
+    ----------
+    smiles : list of str
+        SMILES strings to embed.
+    encoder : torch.nn.Module
+        Frozen Monroe encoder.
+    device : str
+        Torch device name to run the forward pass on.
+    batch_size : int
+        Molecules per forward pass.
+    n_workers : int
+        Worker processes used for graph construction.
+
+    Returns
+    -------
+    dict
+        Mapping of SMILES to embedding vector, keyed by the verbatim input
+        string. Molecules monroe could not featurize are absent from the mapping.
+
+    """
+    _, embed_smiles = _import_monroe()
+    return embed_smiles(
+        smiles,
+        encoder,
+        device=device,
+        batch_size=batch_size,
+        n_workers=n_workers,
+    )
+
+
+@featurizers.register("MonroeFeaturizer")
+class MonroeFeaturizer(FeaturizerBase):
+    """
+    Return Monroe graph-level embeddings for SMILES.
+
+    Monroe is a GRIT transformer pretrained jointly on PM6 quantum-chemical
+    properties and PCBA bioassay labels. This featurizer runs its encoder frozen:
+    the pretrained weights are used as-is and no training is performed.
+
+    The published checkpoint is downloaded and cached under ``~/.openadmet`` on
+    first use, verified against a pinned sha256. Set ``checkpoint_path`` to use a
+    locally trained encoder instead.
+
+    Monroe drops molecules whose graph it cannot build rather than raising. Those
+    positions are reported through the returned index array, which a
+    ``FeatureConcatenator`` intersects away. Callers that use ``featurize``
+    directly must apply the indices themselves to keep features aligned with
+    their targets.
+
+    Attributes
+    ----------
+    type : ClassVar[str]
+        The type of the featurizer.
+    checkpoint_path : Path or None
+        Directory holding ``config.json`` and ``weights.pt``, by default None,
+        which downloads and caches the published checkpoint.
+    accelerator : str
+        Device to use for inference, by default "auto", which resolves like
+        Lightning's auto accelerator: TPU, MPS, or CUDA where available,
+        otherwise CPU.
+    batch_size : int
+        Number of molecules per forward pass, by default 32.
+    n_workers : int or None
+        Worker processes used for graph construction, by default None, which
+        uses ``os.cpu_count()``.
+    use_ema : bool
+        Whether to load the checkpoint's exponential-moving-average weights, by
+        default False. The published checkpoint ships no EMA weights, so this
+        requires ``checkpoint_path``.
+
+    Notes
+    -----
+    **Embeddings are not reproducible across runs.** Monroe builds a conformer
+    per molecule with ETKDGv3 and never sets ``randomSeed``, and the pinned
+    checkpoint has ``zero_vn_edge_rbf`` disabled, so the arbitrary coordinate
+    frame of that conformer reaches the features. Featurizing the same molecule
+    twice yields two different vectors, and monroe exposes no seed to change
+    that. Materialize features once and reuse them rather than re-featurizing:
+    in particular, features used for training and features used at inference
+    must come from the same featurization pass.
+
+    Monroe forks its graph-building pool after the encoder has been moved to the
+    device. On a CUDA host this forks a process with an initialized CUDA
+    context. Set ``n_workers=1`` to avoid the pool, or featurize with
+    ``accelerator="cpu"``, if you hit fork-related hangs.
+
+    Monroe identifies molecules by the verbatim SMILES string it was handed, and
+    routes structures through an InChI round trip, which normalizes tautomers and
+    discards enhanced (AND/OR) stereo. Defined tetrahedral and double-bond stereo
+    survive. As elsewhere in this package, inputs are expected to be canonical,
+    salt-stripped SMILES; standardization belongs upstream of the featurizer.
+
+    A ``checkpoint_path`` whose ``config.json`` disagrees with its ``weights.pt``
+    builds a partially randomly-initialized encoder, because monroe loads state
+    with ``strict=False``. Point at a config and weights from the same run.
+
+    """
+
+    type: ClassVar[str] = "MonroeFeaturizer"
+
+    checkpoint_path: Path | None = Field(
+        default=None,
+        description="Local Monroe checkpoint directory; None downloads the published one",
+    )
+    accelerator: str = "auto"
+    batch_size: int = Field(default=32, ge=1)
+    n_workers: int | None = Field(default=None, ge=1)
+    use_ema: bool = False
+
+    # Cached after a successful build, so featurizing several partitions loads once
+    _encoder: torch.nn.Module | None = PrivateAttr(default=None)
+
+    @field_validator("accelerator")
+    @classmethod
+    def validate_accelerator(cls, value: str) -> str:
+        """
+        Validate that the accelerator resolves to a torch-recognized device.
+
+        Checking eagerly here means a bad accelerator fails at construction time
+        rather than part-way through a featurization run.
+
+        Parameters
+        ----------
+        value : str
+            Accelerator value to validate.
+
+        Returns
+        -------
+        str
+            The validated accelerator value.
+
+        Raises
+        ------
+        ValueError
+            If the value does not resolve to a torch device.
+
+        """
+        try:
+            torch.device(_resolve_device(value))
+        except RuntimeError as e:
+            raise ValueError(f"Invalid accelerator {value!r}: {e}") from e
+        return value
+
+    @field_validator("checkpoint_path")
+    @classmethod
+    def validate_checkpoint_path(cls, value: Path | None) -> Path | None:
+        """
+        Check the path holds both checkpoint files without loading the weights.
+
+        Parameters
+        ----------
+        value : Path or None
+            The configured checkpoint directory.
+
+        Returns
+        -------
+        Path or None
+            The validated directory.
+
+        Raises
+        ------
+        ValueError
+            If the directory, its config.json, or its weights.pt is missing.
+
+        """
+        if value is None:
+            return None
+
+        value = Path(value)
+
+        if not value.is_dir():
+            raise ValueError(f"Monroe checkpoint directory {value} does not exist.")
+
+        for filename in ("config.json", "weights.pt"):
+            if not (value / filename).is_file():
+                raise ValueError(
+                    f"Monroe checkpoint directory {value} has no {filename}, so it "
+                    "is not a Monroe checkpoint."
+                )
+
+        return value
+
+    @model_validator(mode="after")
+    def check_ema_is_available(self):
+        """
+        Check EMA weights can exist for the configured checkpoint.
+
+        The published checkpoint ships only config.json and weights.pt, so
+        requesting EMA weights from it downloads 300 MB before failing inside
+        monroe. The recipe answers this without touching the network.
+
+        Raises
+        ------
+        ValueError
+            If EMA weights are requested from the published checkpoint.
+
+        """
+        if self.use_ema and self.checkpoint_path is None:
+            raise ValueError(
+                "use_ema is set, but the published Monroe checkpoint ships no EMA "
+                "weights. Leave use_ema unset, or set checkpoint_path to a "
+                "checkpoint containing ema_weights.pt."
+            )
+
+        return self
+
+    @property
+    def embedding_dim(self) -> int:
+        """
+        Return the width of the emitted embeddings, without loading any weights.
+
+        Returns
+        -------
+        int
+            The encoder hidden dimension.
+
+        Raises
+        ------
+        ValueError
+            If a configured checkpoint's config.json cannot be parsed or does
+            not declare an encoder hidden dimension.
+
+        """
+        if self.checkpoint_path is None:
+            return _MONROE_EMBEDDING_DIM
+
+        config_path = self.checkpoint_path / "config.json"
+        try:
+            config = json.loads(config_path.read_text())
+            return config["encoder"]["hidden_dim"]
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            raise ValueError(
+                f"Monroe checkpoint config {config_path} does not declare "
+                f"encoder.hidden_dim: {e}"
+            ) from e
+
+    @property
+    def encoder(self) -> torch.nn.Module:
+        """Return the frozen Monroe encoder, building it on first access."""
+        if self._encoder is None:
+            checkpoint_dir = self.checkpoint_path or _download_monroe_checkpoint()
+
+            # Cache only after the load succeeds, so a failure is not memoized
+            self._encoder = _load_encoder(checkpoint_dir, self.use_ema)
+
+        return self._encoder
+
+    def _empty_features(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return the zero-row result, shaped so concatenation stays well defined."""
+        return (
+            np.empty((0, self.embedding_dim), dtype=np.float32),
+            np.empty(0, dtype=int),
+        )
+
+    def featurize(self, smiles: Iterable[str]) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Featurize a list of SMILES strings.
+
+        Parameters
+        ----------
+        smiles : Iterable[str]
+            Canonical, salt-stripped SMILES strings to featurize. Entries Monroe
+            cannot build a graph for are dropped rather than raising, and are
+            reported through the returned indices.
+
+        Returns
+        -------
+        tuple
+            Tuple of (features, indices). Features is a 2D numpy array of shape
+            (n_featurized, embedding_dim) and indices is a 1D numpy array giving
+            the input position of each feature row, in input order.
+
+        Raises
+        ------
+        RuntimeError
+            If monroe returns vectors of an unexpected rank or width.
+
+        """
+        smiles_list = list(smiles)
+
+        # Shaped from the config, so an empty input never downloads or builds
+        if not smiles_list:
+            return self._empty_features()
+
+        # monroe falls back to os.sched_getaffinity when this is None, which does
+        # not exist on macOS, so always hand it an explicit count
+        workers = os.cpu_count() or 1 if self.n_workers is None else self.n_workers
+
+        # Conformer generation dominates the cost and monroe collapses repeats in
+        # its result anyway, so pay for each distinct structure once
+        unique_smiles = list(dict.fromkeys(smiles_list))
+
+        embedded = _embed_smiles(
+            unique_smiles,
+            self.encoder,
+            device=_resolve_device(self.accelerator),
+            batch_size=self.batch_size,
+            n_workers=workers,
+        )
+
+        # monroe keys its result by the verbatim input string, so walking the
+        # input restores the caller's order and repeats resolve to one vector
+        kept = [i for i, smi in enumerate(smiles_list) if smi in embedded]
+
+        if len(kept) < len(smiles_list):
+            self._warn_dropped(smiles_list, embedded)
+
+        if not kept:
+            return self._empty_features()
+
+        features = np.stack([embedded[smiles_list[i]] for i in kept])
+        self._check_shape(features)
+
+        return features.astype(np.float32), np.asarray(kept, dtype=int)
+
+    def _warn_dropped(
+        self, smiles_list: list[str], embedded: dict[str, np.ndarray]
+    ) -> None:
+        """
+        Log which distinct structures Monroe could not featurize.
+
+        Parameters
+        ----------
+        smiles_list : list of str
+            The full input, in order.
+        embedded : dict
+            Monroe's result, keyed by the SMILES it succeeded on.
+
+        """
+        dropped = [smi for smi in dict.fromkeys(smiles_list) if smi not in embedded]
+
+        shown = ", ".join(dropped[:_MAX_REPORTED_DROPS])
+        if len(dropped) > _MAX_REPORTED_DROPS:
+            shown += f", ... ({len(dropped) - _MAX_REPORTED_DROPS} more)"
+
+        logger.warning(
+            "Monroe could not featurize {} of {} distinct structures; the "
+            "affected rows are excluded from the returned indices: {}",
+            len(dropped),
+            len(dict.fromkeys(smiles_list)),
+            shown,
+        )
+
+    def _check_shape(self, features: np.ndarray) -> None:
+        """
+        Check monroe's vectors match the width this featurizer advertises.
+
+        ``embedding_dim`` shapes the empty result, so a disagreement would give a
+        partition with no valid molecules a different column count from a normal
+        one, silently.
+
+        Parameters
+        ----------
+        features : np.ndarray
+            The stacked embedding matrix.
+
+        Raises
+        ------
+        RuntimeError
+            If the matrix is not 2D or its width is not ``embedding_dim``.
+
+        """
+        expected = self.embedding_dim
+
+        if features.ndim != 2:
+            raise RuntimeError(
+                f"Monroe returned rank-{features.ndim - 1} vectors; expected one "
+                "vector per molecule."
+            )
+
+        if features.shape[1] != expected:
+            raise RuntimeError(
+                f"Monroe returned {features.shape[1]}-wide embeddings, but this "
+                f"checkpoint declares {expected}."
+            )

--- a/openadmet/models/tests/unit/features/test_monroe.py
+++ b/openadmet/models/tests/unit/features/test_monroe.py
@@ -1,0 +1,551 @@
+"""Tests for MonroeFeaturizer."""
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from openadmet.models.features import monroe as monroe_module
+from openadmet.models.features.combine import FeatureConcatenator
+from openadmet.models.features.feature_base import get_featurizer_class
+from openadmet.models.features.molfeat_fingerprint import FingerprintFeaturizer
+from openadmet.models.features.monroe import (
+    _VERIFIED_MARKER,
+    MonroeFeaturizer,
+    _download_monroe_checkpoint,
+)
+
+
+@pytest.fixture
+def smiles():
+    return ["CCO", "CCN", "c1ccccc1"]
+
+
+@pytest.fixture
+def featurizer_factory(mocker):
+    """
+    Build a featurizer with a seeded encoder and monroe's embedder patched out.
+
+    monroe's embed_smiles spawns a process pool to build conformers, which is the
+    external boundary here; everything this module owns (order reconstruction,
+    drop reporting, dtype, the index contract) sits on this side of it. The
+    upstream contract this stand-in assumes is pinned separately by
+    test_real_embed_smiles_contract.
+    """
+
+    def _make(vectors, dim=720, **kwargs):
+        def _embed(smiles, encoder, device, batch_size, n_workers):
+            return {
+                smi: np.full(dim, value, dtype=np.float64)
+                for smi, value in vectors.items()
+            }
+
+        embed_mock = mocker.patch.object(
+            monroe_module, "_embed_smiles", autospec=True, side_effect=_embed
+        )
+
+        featurizer = MonroeFeaturizer(**kwargs)
+
+        # Any non-None object satisfies the lazy encoder property; the patched
+        # embedder ignores it
+        featurizer._encoder = object()
+
+        return featurizer, embed_mock
+
+    return _make
+
+
+@pytest.fixture
+def local_checkpoint(tmp_path):
+    """A checkpoint directory whose config declares a narrow, non-default width."""
+    ckpt_dir = tmp_path / "monroe_ckpt"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "config.json").write_text(json.dumps({"encoder": {"hidden_dim": 8}}))
+    (ckpt_dir / "weights.pt").write_bytes(b"")
+    return ckpt_dir
+
+
+@pytest.fixture
+def pin_artifact(mocker):
+    """Shrink the pinned artifact constants so download tests move bytes, not 300 MB."""
+
+    def _apply(payload: bytes):
+        mocker.patch.object(
+            monroe_module, "_MONROE_WEIGHTS_SHA256", hashlib.sha256(payload).hexdigest()
+        )
+        mocker.patch.object(monroe_module, "_MONROE_WEIGHTS_BYTES", len(payload))
+
+    return _apply
+
+
+@pytest.fixture
+def fake_download(mocker):
+    """Patch urlretrieve so it writes canned bytes instead of reaching the network."""
+
+    def _apply(config: bytes, weights: bytes):
+        def _write(url, destination):
+            destination = Path(destination)
+
+            # The real urlretrieve writes to the scratch name the caller chose,
+            # so match on the artifact rather than the process-private suffix
+            key = "config" if "config" in destination.name else "weights"
+            destination.write_bytes(config if key == "config" else weights)
+            return destination, None
+
+        return mocker.patch.object(
+            monroe_module, "urlretrieve", autospec=True, side_effect=_write
+        )
+
+    return _apply
+
+
+def _cache_dir(root: Path) -> Path:
+    return root / "monroe" / monroe_module._MONROE_CKPT_COMMIT
+
+
+@pytest.mark.parametrize("accelerator", ["cpu", "gpu", "mps", "cuda:0"])
+def test_accelerator_validator_accepts_known_values(accelerator):
+    """cpu, gpu, and unaliased torch device spellings must all construct cleanly."""
+    assert MonroeFeaturizer(accelerator=accelerator).accelerator == accelerator
+
+
+def test_accelerator_validator_rejects_bad_value():
+    """An accelerator torch.device() cannot parse must fail at construction time."""
+    with pytest.raises(ValueError, match="Invalid accelerator"):
+        MonroeFeaturizer(accelerator="not_a_real_device")
+
+
+def test_checkpoint_path_must_exist(tmp_path):
+    with pytest.raises(ValueError, match="does not exist"):
+        MonroeFeaturizer(checkpoint_path=tmp_path / "nowhere")
+
+
+def test_checkpoint_path_without_config_rejected(tmp_path):
+    (tmp_path / "weights.pt").write_bytes(b"")
+
+    with pytest.raises(ValueError, match="no config.json"):
+        MonroeFeaturizer(checkpoint_path=tmp_path)
+
+
+def test_checkpoint_path_without_weights_rejected(tmp_path):
+    """A directory monroe would fail to load must be rejected at construction."""
+    (tmp_path / "config.json").write_text("{}")
+
+    with pytest.raises(ValueError, match="no weights.pt"):
+        MonroeFeaturizer(checkpoint_path=tmp_path)
+
+
+def test_use_ema_without_checkpoint_rejected():
+    """The published checkpoint ships no EMA weights, so this must fail before downloading."""
+    with pytest.raises(ValueError, match="no EMA"):
+        MonroeFeaturizer(use_ema=True)
+
+
+@pytest.mark.parametrize(("field", "value"), [("n_workers", 0), ("batch_size", 0)])
+def test_non_positive_worker_and_batch_counts_rejected(field, value):
+    """Zero is a silently degenerate value for both, so reject it at the boundary."""
+    with pytest.raises(ValueError):
+        MonroeFeaturizer(**{field: value})
+
+
+def test_featurize_shape_dtype_indices(smiles, featurizer_factory):
+    featurizer, _ = featurizer_factory({"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0})
+
+    features, indices = featurizer.featurize(smiles)
+
+    assert features.shape == (3, 720)
+    assert features.dtype == np.float32
+    np.testing.assert_array_equal(indices, np.arange(3))
+
+
+def test_featurize_rows_follow_input_order(smiles, featurizer_factory):
+    """monroe returns a SMILES-keyed dict, so row order must come from the input."""
+    featurizer, _ = featurizer_factory({"c1ccccc1": 3.0, "CCO": 1.0, "CCN": 2.0})
+
+    features, _ = featurizer.featurize(smiles)
+
+    np.testing.assert_allclose(features[:, 0], [1.0, 2.0, 3.0])
+
+
+def test_featurize_reports_dropped_molecules(smiles, featurizer_factory):
+    """A molecule monroe omits must be absent from both the rows and the indices."""
+    featurizer, _ = featurizer_factory({"CCO": 1.0, "c1ccccc1": 3.0})
+
+    features, indices = featurizer.featurize(smiles)
+
+    assert features.shape == (2, 720)
+    np.testing.assert_array_equal(indices, np.array([0, 2]))
+    np.testing.assert_allclose(features[:, 0], [1.0, 3.0])
+
+
+def test_drop_warning_names_the_failed_smiles(smiles, featurizer_factory):
+    """A bare count leaves the user unable to find the offending structure."""
+    from loguru import logger
+
+    featurizer, _ = featurizer_factory({"CCO": 1.0, "c1ccccc1": 3.0})
+
+    captured = []
+    handler_id = logger.add(
+        lambda msg: captured.append(msg.record["message"]), level="WARNING"
+    )
+    try:
+        featurizer.featurize(smiles)
+    finally:
+        logger.remove(handler_id)
+
+    assert any("CCN" in message for message in captured)
+
+
+def test_featurize_all_dropped_returns_empty(smiles, featurizer_factory):
+    featurizer, _ = featurizer_factory({})
+
+    features, indices = featurizer.featurize(smiles)
+
+    assert features.shape == (0, 720)
+    assert indices.shape == (0,)
+
+
+def test_featurize_duplicate_smiles_repeat_vector(featurizer_factory):
+    """Duplicates collapse in monroe's dict, so each position must get its vector back."""
+    featurizer, _ = featurizer_factory({"CCO": 1.0, "CCN": 2.0})
+
+    features, indices = featurizer.featurize(["CCO", "CCN", "CCO"])
+
+    assert features.shape == (3, 720)
+    np.testing.assert_array_equal(indices, np.arange(3))
+    np.testing.assert_allclose(features[:, 0], [1.0, 2.0, 1.0])
+
+
+def test_duplicates_are_embedded_once(featurizer_factory):
+    """Conformer generation dominates the cost, so repeats must not be sent twice."""
+    featurizer, embed_mock = featurizer_factory({"CCO": 1.0, "CCN": 2.0})
+
+    featurizer.featurize(["CCO", "CCN", "CCO", "CCO"])
+
+    assert embed_mock.call_args.args[0] == ["CCO", "CCN"]
+
+
+def test_featurize_always_passes_explicit_n_workers(smiles, featurizer_factory):
+    """monroe falls back to os.sched_getaffinity when n_workers is None, which macOS lacks."""
+    featurizer, embed_mock = featurizer_factory(
+        {"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0}
+    )
+
+    featurizer.featurize(smiles)
+
+    assert embed_mock.call_args.kwargs["n_workers"] >= 1
+
+
+def test_featurize_resolves_accelerator_to_a_device(smiles, featurizer_factory):
+    """The accelerator must reach monroe resolved, not passed through verbatim."""
+    featurizer, embed_mock = featurizer_factory(
+        {"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0}, accelerator="gpu"
+    )
+
+    featurizer.featurize(smiles)
+
+    # "gpu" is a Lightning spelling torch.device() cannot parse, so monroe must
+    # be handed the resolved torch name instead
+    assert embed_mock.call_args.kwargs["device"] == "cuda"
+
+
+def test_featurize_forwards_batch_size(smiles, featurizer_factory):
+    featurizer, embed_mock = featurizer_factory(
+        {"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0}, batch_size=7
+    )
+
+    featurizer.featurize(smiles)
+
+    assert embed_mock.call_args.kwargs["batch_size"] == 7
+
+
+def test_featurize_rejects_unexpected_width(smiles, featurizer_factory):
+    """A width disagreeing with the checkpoint would silently reshape empty partitions."""
+    featurizer, _ = featurizer_factory(
+        {"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0}, dim=64
+    )
+
+    with pytest.raises(RuntimeError, match="64-wide"):
+        featurizer.featurize(smiles)
+
+
+def test_featurize_empty_input_returns_empty_without_encoder():
+    """An empty input returns an empty matrix without downloading or building anything."""
+    featurizer = MonroeFeaturizer(accelerator="cpu")
+
+    features, indices = featurizer.featurize([])
+
+    assert features.shape == (0, 720)
+    np.testing.assert_array_equal(indices, np.empty(0, dtype=int))
+    assert featurizer._encoder is None
+
+
+def test_embedding_dim_read_from_local_checkpoint(local_checkpoint):
+    """A local checkpoint's width comes from its config, not the published constant."""
+    featurizer = MonroeFeaturizer(checkpoint_path=local_checkpoint)
+
+    features, _ = featurizer.featurize([])
+
+    assert featurizer.embedding_dim == 8
+    assert features.shape == (0, 8)
+
+
+def test_embedding_dim_rejects_unparseable_config(tmp_path):
+    (tmp_path / "config.json").write_text("not json")
+    (tmp_path / "weights.pt").write_bytes(b"")
+
+    with pytest.raises(ValueError, match="hidden_dim"):
+        MonroeFeaturizer(checkpoint_path=tmp_path).embedding_dim
+
+
+def test_encoder_uses_configured_checkpoint_and_ema(local_checkpoint, mocker):
+    """Both documented options must reach monroe's loader."""
+    load_mock = mocker.patch.object(
+        monroe_module, "_load_encoder", autospec=True, return_value=object()
+    )
+
+    MonroeFeaturizer(checkpoint_path=local_checkpoint, use_ema=True).encoder
+
+    load_mock.assert_called_once_with(local_checkpoint, True)
+
+
+def test_encoder_downloads_when_no_checkpoint_configured(mocker, tmp_path):
+    download_mock = mocker.patch.object(
+        monroe_module,
+        "_download_monroe_checkpoint",
+        autospec=True,
+        return_value=tmp_path / "downloaded",
+    )
+    load_mock = mocker.patch.object(
+        monroe_module, "_load_encoder", autospec=True, return_value=object()
+    )
+
+    MonroeFeaturizer().encoder
+
+    download_mock.assert_called_once()
+    assert load_mock.call_args.args[0] == tmp_path / "downloaded"
+
+
+def test_download_verifies_and_marks_the_cache(tmp_path, pin_artifact, fake_download):
+    payload = b"monroe weights"
+    pin_artifact(payload)
+    fake_download(config=b"{}", weights=payload)
+
+    ckpt_dir = _download_monroe_checkpoint(cache_root=tmp_path)
+
+    assert (ckpt_dir / "weights.pt").read_bytes() == payload
+    assert (ckpt_dir / _VERIFIED_MARKER).read_text() == hashlib.sha256(
+        payload
+    ).hexdigest()
+    assert not list(ckpt_dir.glob("*.part"))
+
+
+def test_download_reuses_verified_cache(tmp_path, mocker, pin_artifact):
+    payload = b"monroe weights"
+    pin_artifact(payload)
+
+    ckpt_dir = _cache_dir(tmp_path)
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "config.json").write_text("{}")
+    (ckpt_dir / "weights.pt").write_bytes(payload)
+    (ckpt_dir / _VERIFIED_MARKER).write_text(hashlib.sha256(payload).hexdigest())
+
+    urlretrieve_mock = mocker.patch.object(monroe_module, "urlretrieve", autospec=True)
+
+    assert _download_monroe_checkpoint(cache_root=tmp_path) == ckpt_dir
+    urlretrieve_mock.assert_not_called()
+
+
+def test_download_redownloads_unverified_cache(tmp_path, pin_artifact, fake_download):
+    """Right-sized weights with no marker are not evidence of a good download."""
+    payload = b"monroe weights"
+    pin_artifact(payload)
+
+    ckpt_dir = _cache_dir(tmp_path)
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "config.json").write_text("{}")
+    (ckpt_dir / "weights.pt").write_bytes(b"stale but righ")
+
+    fake_download(config=b"{}", weights=payload)
+
+    _download_monroe_checkpoint(cache_root=tmp_path)
+
+    assert (ckpt_dir / "weights.pt").read_bytes() == payload
+
+
+def test_download_redownloads_when_weights_replaced_after_marking(
+    tmp_path, pin_artifact, fake_download
+):
+    """A marker must not vouch for weights that were swapped on disk afterwards."""
+    payload = b"monroe weights"
+    pin_artifact(payload)
+
+    ckpt_dir = _cache_dir(tmp_path)
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "config.json").write_text("{}")
+    (ckpt_dir / "weights.pt").write_bytes(b"a different length payload entirely")
+    (ckpt_dir / _VERIFIED_MARKER).write_text(hashlib.sha256(payload).hexdigest())
+
+    fake_download(config=b"{}", weights=payload)
+
+    _download_monroe_checkpoint(cache_root=tmp_path)
+
+    assert (ckpt_dir / "weights.pt").read_bytes() == payload
+
+
+def test_download_rejects_corrupt_weights(tmp_path, pin_artifact, fake_download):
+    """A digest mismatch must raise, leave no scratch file, and mark nothing verified."""
+    pin_artifact(b"the real weights")
+    fake_download(config=b"{}", weights=b"not the weights")
+
+    with pytest.raises(RuntimeError, match="is corrupt"):
+        _download_monroe_checkpoint(cache_root=tmp_path)
+
+    ckpt_dir = _cache_dir(tmp_path)
+    assert not list(ckpt_dir.glob("*.part"))
+    assert not (ckpt_dir / "weights.pt").exists()
+    assert not (ckpt_dir / _VERIFIED_MARKER).exists()
+
+
+def test_missing_monroe_raises_pinned_install_hint(mocker):
+    """Without monroe installed, the error must name the pinned git install command."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name.startswith("monroe"):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    mocker.patch.object(builtins, "__import__", side_effect=_blocked)
+
+    with pytest.raises(ImportError, match=monroe_module._MONROE_CKPT_COMMIT):
+        monroe_module._import_monroe()
+
+
+def test_featurizer_is_registered():
+    assert get_featurizer_class("MonroeFeaturizer") is MonroeFeaturizer
+
+
+def test_featurizer_compatible_with_concatenator(smiles, featurizer_factory):
+    monroe_featurizer, _ = featurizer_factory({"CCO": 1.0, "CCN": 2.0, "c1ccccc1": 3.0})
+    concat = FeatureConcatenator(
+        featurizers=[
+            monroe_featurizer,
+            FingerprintFeaturizer(fp_type="ecfp:4", n_jobs=1),
+        ]
+    )
+
+    X, idx = concat.featurize(smiles)
+
+    # ECFP 2000 + Monroe 720, in the class-name order the concatenator sorts into
+    assert X.shape == (3, 2720)
+    np.testing.assert_array_equal(idx, np.arange(3))
+
+
+def test_concatenator_intersects_monroe_drops(smiles, featurizer_factory):
+    """A molecule Monroe drops must disappear from the concatenated matrix too."""
+    monroe_featurizer, _ = featurizer_factory({"CCO": 1.0, "c1ccccc1": 3.0})
+    concat = FeatureConcatenator(
+        featurizers=[
+            monroe_featurizer,
+            FingerprintFeaturizer(fp_type="ecfp:4", n_jobs=1),
+        ]
+    )
+
+    X, idx = concat.featurize(smiles)
+
+    assert X.shape == (2, 2720)
+    np.testing.assert_array_equal(idx, np.array([0, 2]))
+
+
+@pytest.fixture
+def tiny_monroe_checkpoint(tmp_path):
+    """A real, randomly initialized Monroe encoder small enough to run in a unit test."""
+    pytest.importorskip("monroe")
+
+    import torch
+    from monroe.model.constants import (
+        EDGE_FEAT_LIST_ONE_HOT,
+        NODE_FEAT_LIST_FLOAT,
+        NODE_FEAT_LIST_ONE_HOT,
+    )
+    from monroe.model.grit import GritTransformer
+
+    encoder_cfg = {
+        "hidden_dim": 16,
+        "num_layers": 1,
+        "num_heads": 2,
+        "emb_dim": 8,
+        "walk_len": 4,
+        "rbf_dim": 4,
+        "dropout": 0.0,
+    }
+    encoder = GritTransformer(
+        node_feature_vocab=NODE_FEAT_LIST_ONE_HOT,
+        edge_feature_vocab=EDGE_FEAT_LIST_ONE_HOT,
+        node_float_dim=len(NODE_FEAT_LIST_FLOAT),
+        **encoder_cfg,
+    )
+
+    ckpt_dir = tmp_path / "tiny_monroe"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "config.json").write_text(json.dumps({"encoder": encoder_cfg}))
+    torch.save(
+        {f"encoder.{k}": v for k, v in encoder.state_dict().items()},
+        ckpt_dir / "weights.pt",
+    )
+
+    return ckpt_dir
+
+
+def test_real_load_ckpt_builds_encoder(tiny_monroe_checkpoint):
+    """The real monroe loader must accept the checkpoint layout this featurizer hands it."""
+    from monroe.model.grit import GritTransformer
+
+    loaded = monroe_module._load_encoder(tiny_monroe_checkpoint, use_ema=False)
+
+    assert isinstance(loaded, GritTransformer)
+    assert MonroeFeaturizer(checkpoint_path=tiny_monroe_checkpoint).embedding_dim == 16
+
+
+def test_real_embed_smiles_contract(tiny_monroe_checkpoint):
+    """
+    Pin the upstream contract the patched tests above assume.
+
+    The wrapper identifies molecules by raw input string, so a change in monroe's
+    key normalization would silently empty every result. This is the only test
+    that can catch it.
+    """
+    featurizer = MonroeFeaturizer(
+        checkpoint_path=tiny_monroe_checkpoint, accelerator="cpu", n_workers=1
+    )
+
+    embedded = monroe_module._embed_smiles(
+        ["CCO", "c1ccccc1"],
+        featurizer.encoder,
+        device="cpu",
+        batch_size=2,
+        n_workers=1,
+    )
+
+    # Keyed by the verbatim input string, one 1D vector of the config width each
+    assert set(embedded) == {"CCO", "c1ccccc1"}
+    for vector in embedded.values():
+        assert vector.shape == (16,)
+
+
+def test_real_featurize_end_to_end(tiny_monroe_checkpoint):
+    """The full path must produce the documented (features, indices) shapes."""
+    featurizer = MonroeFeaturizer(
+        checkpoint_path=tiny_monroe_checkpoint, accelerator="cpu", n_workers=1
+    )
+
+    features, indices = featurizer.featurize(["CCO", "c1ccccc1"])
+
+    assert features.shape == (2, 16)
+    assert features.dtype == np.float32
+    np.testing.assert_array_equal(indices, np.arange(2))


### PR DESCRIPTION
## Description

Adds `MonroeFeaturizer` (`openadmet.models.features.monroe`), wrapping the [Monroe](https://github.com/blazejba/monroe) GRIT foundation model as a featurizer alongside the existing `CheMeleonEmbeddingFeaturizer`. It runs the encoder frozen and emits 720-d graph-level embeddings, so Monroe features are usable anywhere a featurizer is accepted: anvil recipes, `FeatureConcatenator`, and the registry.

**Checkpoint handling.** Monroe's published encoder is Git LFS tracked, so `raw.githubusercontent.com` serves a 134-byte pointer rather than the weights; the fetch uses the LFS media endpoint. The URLs are pinned to a commit and the download is verified against the sha256 the LFS pointer publishes, then recorded in a marker file written only after promotion. A cache entry that was truncated, half-written, or replaced on disk fails that check and is re-fetched, rather than being trusted on its size alone and handed to `torch.load`.

**Adapting monroe's contract.** `embed_smiles` returns a `dict` keyed by the verbatim input SMILES and silently omits molecules whose graph it cannot build. The featurizer therefore walks the input to restore caller order, collapses duplicates so each distinct structure costs one conformer, and reports survivors through the index array that `FeatureConcatenator.concatenate` already intersects on. It also always passes an explicit `n_workers`, because monroe otherwise falls back to `os.sched_getaffinity(0)`, which does not exist on macOS — a CI target here.

**Reproducibility, which reviewers should weigh.** Monroe embeddings are *not* deterministic. `predict_structure` builds a conformer with `ETKDGv3()` and never sets `randomSeed` (RDKit's default is `-1`, unseeded), and the pinned checkpoint leaves `zero_vn_edge_rbf` disabled, so the conformer's arbitrary coordinate frame reaches the virtual-node edge RBF. Measured on aspirin: two runs differ by 6.7 Å with conformer centroids at 0.25 vs 1.42 Å. Upstream exposes no seed at any level, so no pydantic field can fix this. It is documented prominently on the class and in the anvil reference instead of being worked around. Note the practical consequence: `anvil/workflow.py:333` featurizes `X_train` and `:347` re-featurizes the full `X` in the same run, so features must be materialized once and reused rather than re-derived at inference time.

The `monroe` package is pinned to the same commit as the checkpoint in both conda environments, because the embedding depends on the graph-construction code (InChI round trip, ETKDG parameters, RBF ranges) as much as on the weights.

## How to verify

```bash
pytest -v openadmet/models/tests/unit/features/test_monroe.py
pytest -q -n auto openadmet/models/tests/unit
pre-commit run --files openadmet/models/features/monroe.py \
    openadmet/models/tests/unit/features/test_monroe.py
```

Confirm the lazy import holds — this must succeed with `monroe` absent, since the module is in the `featurizers` registry group:

```bash
python -c "from openadmet.models.features.feature_base import get_featurizer_class; \
print(get_featurizer_class('MonroeFeaturizer'))"
```

Worth spot-checking: the drop path (a SMILES monroe omits must vanish from both the rows and the indices), the empty-input path (returns a correctly-shaped zero-row matrix without downloading anything), and the corrupt-download path (raises, leaves no scratch file, marks nothing verified).

## Scope

Single concern: one new featurizer plus its registration, docs, and dependency declaration.

## Notes for reviewers

**Verification gap, stated plainly.** Three tests are guarded by `pytest.importorskip("monroe")` and **skipped locally** — `monroe` and `torch-geometric` are installed in no local environment, and installing them pulls `wandb` and `pyarrow` in as well. Those three tests build a tiny real `GritTransformer` in `tmp_path` and exercise the real `load_ckpt`, the real `embed_smiles`, and the full featurize path. **CI will be their first execution**, once the conda-env change lands. Everything else (36 tests) passes locally. The 300 MB checkpoint download is not exercised by any test; the download logic is tested against shrunken pinned constants.

Two upstream behaviors I chose to document rather than defend against, and would take a second opinion on:

- `load_ckpt` uses `strict=False`, so a user-supplied `checkpoint_path` whose `config.json` disagrees with its `weights.pt` yields a partially randomly-initialized encoder emitting plausible-looking vectors. Detecting this means duplicating monroe's `_orig_mod.` key-stripping and paying a second full weight load, so the class docstring warns instead.
- `embed_smiles` moves the encoder to the device *before* forking its graph-building pool, so `accelerator="auto"` on a CUDA host forks a CUDA-initialized parent. The docstring names the mitigations (`n_workers=1`, or `accelerator="cpu"`) rather than silently overriding the user's accelerator choice.

Also note monroe routes structures through an InChI round trip, which normalizes tautomers and discards enhanced (AND/OR) stereo; defined tetrahedral and double-bond stereo survive. As elsewhere in this package, inputs are expected to be canonical, salt-stripped SMILES, and standardization stays upstream of the featurizer.

## Quality Assurance & AI Policy
To maintain project quality and respect maintainer bandwidth, please confirm the following:

- [ ] **Manual Verification:** I have manually reviewed and tested the code in this PR.
- [ ] **AI-Assisted Content:** If AI tools were used (e.g., Copilot, ChatGPT), I have personally verified the logic, edge cases, and compliance with the existing codebase. I confirm the code is not a "blind" AI generation.
- [ ] **Minimal Review:** I believe this PR is in a state that requires minimal intervention or correction from maintainers.
- [ ] **Scoped Change:** This PR addresses a single, well-scoped issue rather than multiple unrelated changes.

## Status
- [ ] Ready to go (Checking this signals to maintainers that the PR is ready for final review)

## Developers Certificate of Origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenADMET/openadmet_toolkit/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
